### PR TITLE
Add sale finalized hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sg-controllers"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3cb8c8181b876427355252453c44aff1f83111be9af1981a6b3e151305e7931"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "schemars",
+ "serde",
+ "sg-std",
+ "thiserror",
+]
+
+[[package]]
 name = "sg-marketplace"
 version = "0.1.1"
 dependencies = [
@@ -662,6 +676,7 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
+ "sg-controllers",
  "sg-multi-test",
  "sg-std",
  "sg1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "sg-controllers"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cb8c8181b876427355252453c44aff1f83111be9af1981a6b3e151305e7931"
+checksum = "8139d4ec93b30e68b5fe598076bf80bc778e950e1b1af6e7cd7a38da439bbc79"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,20 +157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-controllers"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc6d042b14823b0e9f33f5cdd67a1eb9b16a7d79f7547b1a73c8870b518b97b"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cw-multi-test"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,7 +652,6 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-controllers",
  "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-controllers"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc6d042b14823b0e9f33f5cdd67a1eb9b16a7d79f7547b1a73c8870b518b97b"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw-utils",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw-multi-test"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +652,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
+ "cw-controllers",
  "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,100 @@
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Parameters
+
+Licensor:             Public Awesome
+
+Licensed Work:        Stargaze Marketplace V1
+                      The Licensed Work is (c) 2021 Public Awesome
+
+Additional Use Grant: Any uses listed and defined at
+                      https://github.com/public-awesome/marketplace/README.md
+
+Change Date:          The earlier of 2024-05-01 or a date specified by
+                      Stargaze governance
+
+Change License:       GNU General Public License v2.0 or later
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = { version = "1.0.30" }
 sg-std = "0.12.0"
 cw-utils = "0.13.2"
 sg1 = "0.12.1"
+cw-controllers = "0.13.2"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -47,7 +47,6 @@ thiserror = { version = "1.0.30" }
 sg-std = "0.12.0"
 cw-utils = "0.13.2"
 sg1 = "0.12.1"
-cw-controllers = "0.13.2"
 sg-controllers = "0.12.0"
 
 [dev-dependencies]

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -48,6 +48,7 @@ sg-std = "0.12.0"
 cw-utils = "0.13.2"
 sg1 = "0.12.1"
 cw-controllers = "0.13.2"
+sg-controllers = "0.12.0"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -47,7 +47,7 @@ thiserror = { version = "1.0.30" }
 sg-std = "0.12.0"
 cw-utils = "0.13.2"
 sg1 = "0.12.1"
-sg-controllers = "0.12.0"
+sg-controllers = "0.12.1"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -377,13 +377,13 @@
       "additionalProperties": false
     },
     {
-      "description": "Show all registered hooks Return type: `HooksResponse`",
+      "description": "Show all registered sale finalized hooks Return type: `HooksResponse`",
       "type": "object",
       "required": [
-        "hooks"
+        "sale_finalized_hooks"
       ],
       "properties": {
-        "hooks": {
+        "sale_finalized_hooks": {
           "type": "object"
         }
       },

--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -300,6 +300,81 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Get data for a specific collection bid Return type: `CollectionBidResponse`",
+      "type": "object",
+      "required": [
+        "collection_bid"
+      ],
+      "properties": {
+        "collection_bid": {
+          "type": "object",
+          "required": [
+            "bidder",
+            "collection"
+          ],
+          "properties": {
+            "bidder": {
+              "type": "string"
+            },
+            "collection": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Get all collection bids by a bidder Return type: `CollectionBidsResponse`",
+      "type": "object",
+      "required": [
+        "collection_bids_by_bidder"
+      ],
+      "properties": {
+        "collection_bids_by_bidder": {
+          "type": "object",
+          "required": [
+            "bidder"
+          ],
+          "properties": {
+            "bidder": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Get all collection bids for a collection sorted by price Return type: `CollectionBidsResponse`",
+      "type": "object",
+      "required": [
+        "collection_bids_sorted_by_price"
+      ],
+      "properties": {
+        "collection_bids_sorted_by_price": {
+          "type": "object",
+          "required": [
+            "collection"
+          ],
+          "properties": {
+            "collection": {
+              "type": "string"
+            },
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -375,6 +375,19 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Show all registered hooks Return type: `HooksResponse`",
+      "type": "object",
+      "required": [
+        "hooks"
+      ],
+      "properties": {
+        "hooks": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::StdError;
+use cw_controllers::HookError;
 use cw_utils::PaymentError;
 use thiserror::Error;
 
@@ -42,4 +43,7 @@ pub enum ContractError {
 
     #[error("{0}")]
     BidPaymentError(#[from] PaymentError),
+
+    #[error("{0}")]
+    Hook(#[from] HookError),
 }

--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::StdError;
-use cw_controllers::HookError;
 use cw_utils::PaymentError;
+use sg_controllers::HookError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -3,7 +3,7 @@ use crate::helpers::map_validate;
 use crate::msg::{ExecuteMsg, InstantiateMsg, SaleFinalizedHookMsg};
 use crate::state::{
     ask_key, asks, bid_key, bids, collection_bid_key, collection_bids, Ask, Bid, CollectionBid,
-    SudoParams, TokenId, HOOKS, SUDO_PARAMS,
+    SudoParams, TokenId, SALE_FINALIZED_HOOKS, SUDO_PARAMS,
 };
 use cosmwasm_std::{
     coin, entry_point, to_binary, Addr, BankMsg, Coin, Decimal, Deps, DepsMut, Env, MessageInfo,
@@ -597,7 +597,7 @@ fn finalize_sale(
         buyer: recipient.to_string(),
     };
 
-    let submsg = HOOKS.prepare_hooks(deps.storage, |h| {
+    let submsg = SALE_FINALIZED_HOOKS.prepare_hooks(deps.storage, |h| {
         msg.clone().into_cosmos_msg(h).map(SubMsg::new)
     })?;
 

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -344,6 +344,7 @@ pub fn execute_set_bid(
             deps,
             collection.clone(),
             token_id,
+            owner.clone(),
             bidder.clone(),
             ask.funds_recipient.unwrap_or(owner),
             coin(ask.price.u128(), NATIVE_DENOM),
@@ -439,6 +440,7 @@ pub fn execute_accept_bid(
         deps,
         collection.clone(),
         token_id,
+        info.sender.clone(),
         bidder.clone(),
         ask.funds_recipient.unwrap_or(info.sender),
         coin(bid.price.u128(), NATIVE_DENOM),
@@ -530,6 +532,7 @@ pub fn execute_accept_collection_bid(
         deps,
         collection.clone(),
         token_id,
+        info.sender.clone(),
         bidder.clone(),
         info.sender,
         coin(bid.price.u128(), NATIVE_DENOM),
@@ -564,6 +567,7 @@ fn finalize_sale(
     deps: DepsMut,
     collection: Addr,
     token_id: u32,
+    seller: Addr,
     recipient: Addr,
     funds_recipient: Addr,
     price: Coin,
@@ -589,7 +593,7 @@ fn finalize_sale(
     let msg = SaleFinalizedHookMsg {
         collection: collection.to_string(),
         token_id,
-        seller: "seller".to_string(),
+        seller: seller.to_string(),
         buyer: recipient.to_string(),
     };
 

--- a/contracts/marketplace/src/helpers.rs
+++ b/contracts/marketplace/src/helpers.rs
@@ -1,4 +1,29 @@
-use cosmwasm_std::{Addr, Api, StdResult};
+use cosmwasm_std::{to_binary, Addr, Api, StdResult, WasmMsg};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sg_std::CosmosMsg;
+
+use crate::msg::ExecuteMsg;
+
+/// MarketplaceContract is a wrapper around Addr that provides a lot of helpers
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MarketplaceContract(pub Addr);
+
+impl MarketplaceContract {
+    pub fn addr(&self) -> Addr {
+        self.0.clone()
+    }
+
+    pub fn call<T: Into<ExecuteMsg>>(&self, msg: T) -> StdResult<CosmosMsg> {
+        let msg = to_binary(&msg.into())?;
+        Ok(WasmMsg::Execute {
+            contract_addr: self.addr().into(),
+            msg,
+            funds: vec![],
+        }
+        .into())
+    }
+}
 
 pub fn map_validate(api: &dyn Api, addresses: &[String]) -> StdResult<Vec<Addr>> {
     addresses

--- a/contracts/marketplace/src/helpers.rs
+++ b/contracts/marketplace/src/helpers.rs
@@ -1,0 +1,8 @@
+use cosmwasm_std::{Addr, Api, StdResult};
+
+pub fn map_validate(api: &dyn Api, addresses: &[String]) -> StdResult<Vec<Addr>> {
+    addresses
+        .iter()
+        .map(|addr| api.addr_validate(addr))
+        .collect()
+}

--- a/contracts/marketplace/src/lib.rs
+++ b/contracts/marketplace/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod error;
 pub mod execute;
+mod helpers;
 pub mod msg;
 mod multitest;
 pub mod query;
 pub mod state;
+pub mod sudo;
 mod unit_tests;

--- a/contracts/marketplace/src/lib.rs
+++ b/contracts/marketplace/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod error;
 pub mod execute;
-mod helpers;
+pub mod helpers;
 pub mod msg;
 mod multitest;
 pub mod query;

--- a/contracts/marketplace/src/lib.rs
+++ b/contracts/marketplace/src/lib.rs
@@ -6,4 +6,5 @@ mod multitest;
 pub mod query;
 pub mod state;
 pub mod sudo;
+#[cfg(test)]
 mod unit_tests;

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -1,7 +1,8 @@
 use crate::state::{Ask, Bid, CollectionBid, SudoParams, TokenId};
-use cosmwasm_std::{to_binary, Addr, Binary, Coin, CosmosMsg, StdResult, Timestamp, WasmMsg};
+use cosmwasm_std::{to_binary, Addr, Binary, Coin, StdResult, Timestamp, WasmMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use sg_std::CosmosMsg;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -221,17 +221,19 @@ pub struct CollectionBidsResponse {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct SaleFinalizedHookMsg {
-    pub collection: Collection,
-    pub token_id: TokenId,
-    pub seller: Seller,
+    pub collection: String,
+    pub token_id: u32,
+    pub seller: String,
+    pub buyer: String,
 }
 
 impl SaleFinalizedHookMsg {
-    pub fn new(collection: Collection, token_id: TokenId, seller: Seller) -> Self {
+    pub fn new(collection: String, token_id: u32, seller: String, buyer: String) -> Self {
         SaleFinalizedHookMsg {
             collection,
             token_id,
             seller,
+            buyer,
         }
     }
 

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -82,6 +82,10 @@ pub enum SudoMsg {
         bid_expiry: Option<(u64, u64)>,
         operators: Option<Vec<String>>,
     },
+    /// Add a new hook to be informed of all trades
+    AddHook { hook: String },
+    /// Remove a hook
+    RemoveHook { hook: String },
 }
 
 pub type Collection = String;

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -168,6 +168,9 @@ pub enum QueryMsg {
         collection: Collection,
         limit: Option<u32>,
     },
+    /// Show all registered hooks
+    /// Return type: `HooksResponse`
+    Hooks {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -84,9 +84,9 @@ pub enum SudoMsg {
         operators: Option<Vec<String>>,
     },
     /// Add a new hook to be informed of all trades
-    AddHook { hook: String },
+    AddSaleFinalizedHook { hook: String },
     /// Remove a hook
-    RemoveHook { hook: String },
+    RemoveSaleFinalizedHook { hook: String },
 }
 
 pub type Collection = String;

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -158,13 +158,6 @@ pub enum QueryMsg {
     /// Get all collection bids by a bidder
     /// Return type: `CollectionBidsResponse`
     CollectionBidsByBidder { bidder: Bidder },
-    /// Get all collection bids for a collection
-    /// Return type: `CollectionBidsResponse`
-    // CollectionBids {
-    //     collection: String,
-    //     start_after: Option<String>,
-    //     limit: Option<u32>,
-    // },
     /// Get all collection bids for a collection sorted by price
     /// Return type: `CollectionBidsResponse`
     CollectionBidsSortedByPrice {

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -169,9 +169,9 @@ pub enum QueryMsg {
         collection: Collection,
         limit: Option<u32>,
     },
-    /// Show all registered hooks
+    /// Show all registered sale finalized hooks
     /// Return type: `HooksResponse`
-    Hooks {},
+    SaleFinalizedHooks {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -1425,7 +1425,7 @@ mod tests {
         // Instantiate and configure contracts
         let (marketplace, _) = setup_contracts(&mut router, &creator).unwrap();
 
-        let add_hook_msg = SudoMsg::AddHook {
+        let add_hook_msg = SudoMsg::AddSaleFinalizedHook {
             hook: "hook".to_string(),
         };
         let res = router.wasm_sudo(marketplace.clone(), &add_hook_msg);
@@ -1438,7 +1438,7 @@ mod tests {
             .unwrap();
         assert_eq!(res.hooks, vec!["hook".to_string()]);
 
-        let remove_hook_msg = SudoMsg::RemoveHook {
+        let remove_hook_msg = SudoMsg::RemoveSaleFinalizedHook {
             hook: "hook".to_string(),
         };
         let res = router.wasm_sudo(marketplace.clone(), &remove_hook_msg);
@@ -1459,7 +1459,7 @@ mod tests {
         // Instantiate and configure contracts
         let (marketplace, collection) = setup_contracts(&mut router, &creator).unwrap();
 
-        let add_hook_msg = SudoMsg::AddHook {
+        let add_hook_msg = SudoMsg::AddSaleFinalizedHook {
             hook: "hook".to_string(),
         };
         let _res = router.wasm_sudo(marketplace.clone(), &add_hook_msg);

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -1494,12 +1494,7 @@ mod tests {
         };
         // Error because the "hook" contract is not deployed
         let _err = router
-            .execute_contract(
-                bidder.clone(),
-                marketplace,
-                &set_bid_msg,
-                &coins(100, NATIVE_DENOM),
-            )
+            .execute_contract(bidder, marketplace, &set_bid_msg, &coins(100, NATIVE_DENOM))
             .unwrap_err();
 
         // If the bid is accepted, the sale would be finalized

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -20,7 +20,7 @@ pub fn contract_nft_marketplace() -> Box<dyn Contract<StargazeMsgWrapper>> {
         crate::execute::instantiate,
         crate::query::query,
     )
-    .with_sudo(crate::execute::sudo);
+    .with_sudo(crate::sudo::sudo);
     Box::new(contract)
 }
 

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -1431,7 +1431,7 @@ mod tests {
         let res = router.wasm_sudo(marketplace.clone(), &add_hook_msg);
         assert!(res.is_ok());
 
-        let query_hooks_msg = QueryMsg::Hooks {};
+        let query_hooks_msg = QueryMsg::SaleFinalizedHooks {};
         let res: HooksResponse = router
             .wrap()
             .query_wasm_smart(marketplace.clone(), &query_hooks_msg)

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -91,7 +91,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&bidder)?,
         )?),
-        QueryMsg::Hooks {} => to_binary(&SALE_FINALIZED_HOOKS.query_hooks(deps)?),
+        QueryMsg::SaleFinalizedHooks {} => to_binary(&SALE_FINALIZED_HOOKS.query_hooks(deps)?),
     }
 }
 

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -4,7 +4,8 @@ use crate::msg::{
     ParamResponse, QueryMsg,
 };
 use crate::state::{
-    ask_key, asks, bids, collection_bid_key, collection_bids, TokenId, HOOKS, SUDO_PARAMS,
+    ask_key, asks, bids, collection_bid_key, collection_bids, TokenId, SALE_FINALIZED_HOOKS,
+    SUDO_PARAMS,
 };
 use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Deps, Env, Order, StdResult};
 use cw_storage_plus::{Bound, PrefixBound};
@@ -90,7 +91,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&bidder)?,
         )?),
-        QueryMsg::Hooks {} => to_binary(&HOOKS.query_hooks(deps)?),
+        QueryMsg::Hooks {} => to_binary(&SALE_FINALIZED_HOOKS.query_hooks(deps)?),
     }
 }
 

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -4,7 +4,7 @@ use crate::msg::{
     ParamResponse, QueryMsg,
 };
 use crate::state::{
-    ask_key, asks, bids, collection_bid_key, collection_bids, TokenId, SUDO_PARAMS,
+    ask_key, asks, bids, collection_bid_key, collection_bids, TokenId, HOOKS, SUDO_PARAMS,
 };
 use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Deps, Env, Order, StdResult};
 use cw_storage_plus::{Bound, PrefixBound};
@@ -90,6 +90,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&bidder)?,
         )?),
+        QueryMsg::Hooks {} => to_binary(&HOOKS.query_hooks(deps)?),
     }
 }
 

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{Addr, Timestamp, Uint128};
-use cw_controllers::Hooks;
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, MultiIndex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use sg_controllers::Hooks;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct SudoParams {

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{Addr, Timestamp, Uint128};
+use cw_controllers::Hooks;
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, MultiIndex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -168,3 +169,5 @@ pub fn collection_bids<'a>(
     };
     IndexedMap::new("col_bids", indexes)
 }
+
+pub const HOOKS: Hooks = Hooks::new("hooks");

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -170,4 +170,4 @@ pub fn collection_bids<'a>(
     IndexedMap::new("col_bids", indexes)
 }
 
-pub const HOOKS: Hooks = Hooks::new("hooks");
+pub const SALE_FINALIZED_HOOKS: Hooks = Hooks::new("sale-finalized-hooks");

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -14,6 +14,8 @@ pub struct SudoParams {
 
 pub const SUDO_PARAMS: Item<SudoParams> = Item::new("sudo_params");
 
+pub const SALE_FINALIZED_HOOKS: Hooks = Hooks::new("sale-finalized-hooks");
+
 pub type TokenId = u32;
 
 /// Represents an ask on the marketplace
@@ -169,5 +171,3 @@ pub fn collection_bids<'a>(
     };
     IndexedMap::new("col_bids", indexes)
 }
-
-pub const SALE_FINALIZED_HOOKS: Hooks = Hooks::new("sale-finalized-hooks");

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -23,8 +23,12 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractE
             bid_expiry,
             operators,
         ),
-        SudoMsg::AddHook { hook } => sudo_add_hook(deps, env, api.addr_validate(&hook)?),
-        SudoMsg::RemoveHook { hook } => sudo_remove_hook(deps, api.addr_validate(&hook)?),
+        SudoMsg::AddSaleFinalizedHook { hook } => {
+            sudo_add_hook(deps, env, api.addr_validate(&hook)?)
+        }
+        SudoMsg::RemoveSaleFinalizedHook { hook } => {
+            sudo_remove_hook(deps, api.addr_validate(&hook)?)
+        }
     }
 }
 

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -1,7 +1,7 @@
 use crate::error::ContractError;
 use crate::helpers::map_validate;
 use crate::msg::SudoMsg;
-use crate::state::{HOOKS, SUDO_PARAMS};
+use crate::state::{SALE_FINALIZED_HOOKS, SUDO_PARAMS};
 use cosmwasm_std::{entry_point, Addr, DepsMut, Env};
 use sg_std::Response;
 
@@ -24,10 +24,10 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractE
             operators,
         ),
         SudoMsg::AddSaleFinalizedHook { hook } => {
-            sudo_add_hook(deps, env, api.addr_validate(&hook)?)
+            sudo_add_sale_finalized_hook(deps, env, api.addr_validate(&hook)?)
         }
         SudoMsg::RemoveSaleFinalizedHook { hook } => {
-            sudo_remove_hook(deps, api.addr_validate(&hook)?)
+            sudo_remove_sale_finalized_hook(deps, api.addr_validate(&hook)?)
         }
     }
 }
@@ -54,20 +54,27 @@ pub fn sudo_update_params(
     Ok(Response::new().add_attribute("action", "update_params"))
 }
 
-pub fn sudo_add_hook(deps: DepsMut, _env: Env, hook: Addr) -> Result<Response, ContractError> {
-    HOOKS.add_hook(deps.storage, hook.clone())?;
+pub fn sudo_add_sale_finalized_hook(
+    deps: DepsMut,
+    _env: Env,
+    hook: Addr,
+) -> Result<Response, ContractError> {
+    SALE_FINALIZED_HOOKS.add_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
-        .add_attribute("action", "add_hook")
+        .add_attribute("action", "add_sale_finalized_hook")
         .add_attribute("hook", hook);
     Ok(res)
 }
 
-pub fn sudo_remove_hook(deps: DepsMut, hook: Addr) -> Result<Response, ContractError> {
-    HOOKS.remove_hook(deps.storage, hook.clone())?;
+pub fn sudo_remove_sale_finalized_hook(
+    deps: DepsMut,
+    hook: Addr,
+) -> Result<Response, ContractError> {
+    SALE_FINALIZED_HOOKS.remove_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
-        .add_attribute("action", "remove_hook")
+        .add_attribute("action", "remove_sale_finalized_hook")
         .add_attribute("hook", hook);
     Ok(res)
 }

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -1,0 +1,69 @@
+use crate::error::ContractError;
+use crate::helpers::map_validate;
+use crate::msg::SudoMsg;
+use crate::state::{HOOKS, SUDO_PARAMS};
+use cosmwasm_std::{entry_point, Addr, DepsMut, Env};
+use sg_std::Response;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractError> {
+    let api = deps.api;
+
+    match msg {
+        SudoMsg::UpdateParams {
+            trading_fee_percent,
+            ask_expiry,
+            bid_expiry,
+            operators,
+        } => sudo_update_params(
+            deps,
+            env,
+            trading_fee_percent,
+            ask_expiry,
+            bid_expiry,
+            operators,
+        ),
+        SudoMsg::AddHook { hook } => sudo_add_hook(deps, env, api.addr_validate(&hook)?),
+        SudoMsg::RemoveHook { hook } => sudo_remove_hook(deps, api.addr_validate(&hook)?),
+    }
+}
+
+/// Only governance can update contract params
+pub fn sudo_update_params(
+    deps: DepsMut,
+    _env: Env,
+    trading_fee_percent: Option<u32>,
+    ask_expiry: Option<(u64, u64)>,
+    bid_expiry: Option<(u64, u64)>,
+    operators: Option<Vec<String>>,
+) -> Result<Response, ContractError> {
+    let mut params = SUDO_PARAMS.load(deps.storage)?;
+
+    params.trading_fee_percent = trading_fee_percent.unwrap_or(params.trading_fee_percent);
+    params.ask_expiry = ask_expiry.unwrap_or(params.ask_expiry);
+    params.bid_expiry = bid_expiry.unwrap_or(params.bid_expiry);
+    if let Some(operators) = operators {
+        params.operators = map_validate(deps.api, &operators)?;
+    }
+    SUDO_PARAMS.save(deps.storage, &params)?;
+
+    Ok(Response::new().add_attribute("action", "update_params"))
+}
+
+pub fn sudo_add_hook(deps: DepsMut, _env: Env, hook: Addr) -> Result<Response, ContractError> {
+    HOOKS.add_hook(deps.storage, hook.clone())?;
+
+    let res = Response::new()
+        .add_attribute("action", "add_hook")
+        .add_attribute("hook", hook);
+    Ok(res)
+}
+
+pub fn sudo_remove_hook(deps: DepsMut, hook: Addr) -> Result<Response, ContractError> {
+    HOOKS.remove_hook(deps.storage, hook.clone())?;
+
+    let res = Response::new()
+        .add_attribute("action", "remove_hook")
+        .add_attribute("hook", hook);
+    Ok(res)
+}

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -1,208 +1,208 @@
 #[cfg(test)]
-mod tests {
-    use std::vec;
+use std::vec;
 
-    use crate::error::ContractError;
-    use crate::execute::{execute, instantiate};
-    use crate::msg::{ExecuteMsg, InstantiateMsg};
-    use crate::query::{query_ask_count, query_asks_by_seller, query_bids_by_bidder};
-    use crate::state::{ask_key, asks, bid_key, bids, Ask, Bid};
+use crate::error::ContractError;
+use crate::execute::{execute, instantiate};
+use crate::msg::{ExecuteMsg, InstantiateMsg};
+use crate::query::{query_ask_count, query_asks_by_seller, query_bids_by_bidder};
+use crate::state::{ask_key, asks, bid_key, bids, Ask, Bid};
 
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coin, coins, Addr, DepsMut, StdError, Timestamp, Uint128};
-    use sg_std::NATIVE_DENOM;
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{coin, coins, Addr, DepsMut, StdError, Timestamp, Uint128};
+use sg_std::NATIVE_DENOM;
 
-    const CREATOR: &str = "creator";
-    const COLLECTION: &str = "collection";
-    const TOKEN_ID: u32 = 123;
-    // Governance parameters
-    const TRADING_FEE_PERCENT: u32 = 2; // 2%
-    const MIN_EXPIRY: u64 = 24 * 60 * 60; // 24 hours (in seconds)
-    const MAX_EXPIRY: u64 = 180 * 24 * 60 * 60; // 6 months (in seconds)
+const CREATOR: &str = "creator";
+const COLLECTION: &str = "collection";
+const TOKEN_ID: u32 = 123;
+// Governance parameters
+const TRADING_FEE_PERCENT: u32 = 2; // 2%
+const MIN_EXPIRY: u64 = 24 * 60 * 60; // 24 hours (in seconds)
+const MAX_EXPIRY: u64 = 180 * 24 * 60 * 60; // 6 months (in seconds)
 
-    #[test]
-    fn ask_indexed_map() {
-        let mut deps = mock_dependencies();
-        let collection = Addr::unchecked(COLLECTION);
-        let seller = Addr::unchecked("seller");
+#[test]
+fn ask_indexed_map() {
+    let mut deps = mock_dependencies();
+    let collection = Addr::unchecked(COLLECTION);
+    let seller = Addr::unchecked("seller");
 
-        let ask = Ask {
-            collection: collection.clone(),
-            token_id: TOKEN_ID,
-            seller: seller.clone(),
-            price: Uint128::from(500u128),
-            funds_recipient: None,
-            expires: Timestamp::from_seconds(0),
-            active: true,
-        };
-        let key = ask_key(collection.clone(), TOKEN_ID);
-        let res = asks().save(deps.as_mut().storage, key.clone(), &ask);
-        assert!(res.is_ok());
+    let ask = Ask {
+        collection: collection.clone(),
+        token_id: TOKEN_ID,
+        seller: seller.clone(),
+        price: Uint128::from(500u128),
+        funds_recipient: None,
+        expires: Timestamp::from_seconds(0),
+        active: true,
+    };
+    let key = ask_key(collection.clone(), TOKEN_ID);
+    let res = asks().save(deps.as_mut().storage, key.clone(), &ask);
+    assert!(res.is_ok());
 
-        let ask2 = Ask {
-            collection: collection.clone(),
-            token_id: TOKEN_ID + 1,
-            seller: seller.clone(),
-            price: Uint128::from(500u128),
-            funds_recipient: None,
-            expires: Timestamp::from_seconds(0),
-            active: true,
-        };
-        let key2 = ask_key(collection.clone(), TOKEN_ID + 1);
-        let res = asks().save(deps.as_mut().storage, key2, &ask2);
-        assert!(res.is_ok());
+    let ask2 = Ask {
+        collection: collection.clone(),
+        token_id: TOKEN_ID + 1,
+        seller: seller.clone(),
+        price: Uint128::from(500u128),
+        funds_recipient: None,
+        expires: Timestamp::from_seconds(0),
+        active: true,
+    };
+    let key2 = ask_key(collection.clone(), TOKEN_ID + 1);
+    let res = asks().save(deps.as_mut().storage, key2, &ask2);
+    assert!(res.is_ok());
 
-        let res = asks().load(deps.as_ref().storage, key);
-        assert_eq!(res.unwrap(), ask);
+    let res = asks().load(deps.as_ref().storage, key);
+    assert_eq!(res.unwrap(), ask);
 
-        let res = query_asks_by_seller(deps.as_ref(), seller).unwrap();
-        assert_eq!(res.asks.len(), 2);
-        assert_eq!(res.asks[0], ask);
+    let res = query_asks_by_seller(deps.as_ref(), seller).unwrap();
+    assert_eq!(res.asks.len(), 2);
+    assert_eq!(res.asks[0], ask);
 
-        let res = query_ask_count(deps.as_ref(), collection).unwrap();
-        assert_eq!(res.count, 2);
-    }
-
-    #[test]
-
-    fn bid_indexed_map() {
-        let mut deps = mock_dependencies();
-        let collection = Addr::unchecked(COLLECTION);
-        let bidder = Addr::unchecked("bidder");
-
-        let bid = Bid {
-            collection: collection.clone(),
-            token_id: TOKEN_ID,
-            bidder: bidder.clone(),
-            price: Uint128::from(500u128),
-            expires: Timestamp::from_seconds(0),
-        };
-        let key = bid_key(collection.clone(), TOKEN_ID, bidder.clone());
-        let res = bids().save(deps.as_mut().storage, key.clone(), &bid);
-        assert!(res.is_ok());
-
-        let bid2 = Bid {
-            collection: collection.clone(),
-            token_id: TOKEN_ID + 1,
-            bidder: bidder.clone(),
-            price: Uint128::from(500u128),
-            expires: Timestamp::from_seconds(0),
-        };
-        let key2 = bid_key(collection, TOKEN_ID + 1, bidder.clone());
-        let res = bids().save(deps.as_mut().storage, key2, &bid2);
-        assert!(res.is_ok());
-
-        let res = bids().load(deps.as_ref().storage, key);
-        assert_eq!(res.unwrap(), bid);
-
-        let res = query_bids_by_bidder(deps.as_ref(), bidder).unwrap();
-        assert_eq!(res.bids.len(), 2);
-        assert_eq!(res.bids[0], bid);
-    }
-
-    fn setup_contract(deps: DepsMut) {
-        let msg = InstantiateMsg {
-            operators: vec!["operator".to_string()],
-            trading_fee_percent: TRADING_FEE_PERCENT,
-            ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-        };
-        let info = mock_info(CREATOR, &[]);
-        let res = instantiate(deps, mock_env(), info, msg).unwrap();
-        assert_eq!(0, res.messages.len());
-    }
-
-    #[test]
-    fn proper_initialization() {
-        let mut deps = mock_dependencies();
-
-        let msg = InstantiateMsg {
-            operators: vec!["operator".to_string()],
-            trading_fee_percent: TRADING_FEE_PERCENT,
-            ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-        };
-        let info = mock_info("creator", &coins(1000, NATIVE_DENOM));
-
-        // we can just call .unwrap() to assert this was a success
-        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
-        assert_eq!(0, res.messages.len());
-    }
-
-    #[test]
-    fn try_set_bid() {
-        let mut deps = mock_dependencies();
-        setup_contract(deps.as_mut());
-
-        let broke = mock_info("broke", &[]);
-        let bidder = mock_info("bidder", &coins(1000, NATIVE_DENOM));
-
-        let set_bid_msg = ExecuteMsg::SetBid {
-            collection: COLLECTION.to_string(),
-            token_id: TOKEN_ID,
-            expires: Timestamp::from_seconds(0),
-        };
-
-        // Broke bidder calls Set Bid and gets an error
-        let err = execute(deps.as_mut(), mock_env(), broke, set_bid_msg).unwrap_err();
-        assert_eq!(
-            err,
-            ContractError::BidPaymentError(cw_utils::PaymentError::NoFunds {})
-        );
-
-        let set_bid_msg = ExecuteMsg::SetBid {
-            collection: COLLECTION.to_string(),
-            token_id: TOKEN_ID,
-            expires: mock_env().block.time.plus_seconds(MIN_EXPIRY + 1),
-        };
-
-        // Bidder calls SetBid before an Ask is set, so it should fail
-        let err = execute(deps.as_mut(), mock_env(), bidder, set_bid_msg).unwrap_err();
-        assert_eq!(
-            err,
-            ContractError::Std(StdError::NotFound {
-                kind: "sg_marketplace::state::Ask".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn try_set_ask() {
-        let mut deps = mock_dependencies();
-        setup_contract(deps.as_mut());
-
-        let set_ask = ExecuteMsg::SetAsk {
-            collection: COLLECTION.to_string(),
-            token_id: TOKEN_ID,
-            price: coin(100, NATIVE_DENOM),
-            funds_recipient: None,
-            expires: Timestamp::from_seconds(
-                mock_env().block.time.plus_seconds(MIN_EXPIRY + 1).seconds(),
-            ),
-        };
-
-        // Reject if not called by the media owner
-        let not_allowed = mock_info("random", &[]);
-        let err = execute(deps.as_mut(), mock_env(), not_allowed, set_ask);
-        assert!(err.is_err());
-
-        // Reject wrong denom
-        let set_bad_ask = ExecuteMsg::SetAsk {
-            collection: COLLECTION.to_string(),
-            token_id: TOKEN_ID,
-            price: coin(100, "osmo".to_string()),
-            funds_recipient: None,
-            expires: Timestamp::from_seconds(
-                mock_env().block.time.plus_seconds(MIN_EXPIRY + 1).seconds(),
-            ),
-        };
-        let err = execute(
-            deps.as_mut(),
-            mock_env(),
-            mock_info("creator", &[]),
-            set_bad_ask,
-        )
-        .unwrap_err();
-        assert_eq!(err, ContractError::InvalidPrice {});
-    }
+    let res = query_ask_count(deps.as_ref(), collection).unwrap();
+    assert_eq!(res.count, 2);
 }
+
+#[test]
+
+fn bid_indexed_map() {
+    let mut deps = mock_dependencies();
+    let collection = Addr::unchecked(COLLECTION);
+    let bidder = Addr::unchecked("bidder");
+
+    let bid = Bid {
+        collection: collection.clone(),
+        token_id: TOKEN_ID,
+        bidder: bidder.clone(),
+        price: Uint128::from(500u128),
+        expires: Timestamp::from_seconds(0),
+    };
+    let key = bid_key(collection.clone(), TOKEN_ID, bidder.clone());
+    let res = bids().save(deps.as_mut().storage, key.clone(), &bid);
+    assert!(res.is_ok());
+
+    let bid2 = Bid {
+        collection: collection.clone(),
+        token_id: TOKEN_ID + 1,
+        bidder: bidder.clone(),
+        price: Uint128::from(500u128),
+        expires: Timestamp::from_seconds(0),
+    };
+    let key2 = bid_key(collection, TOKEN_ID + 1, bidder.clone());
+    let res = bids().save(deps.as_mut().storage, key2, &bid2);
+    assert!(res.is_ok());
+
+    let res = bids().load(deps.as_ref().storage, key);
+    assert_eq!(res.unwrap(), bid);
+
+    let res = query_bids_by_bidder(deps.as_ref(), bidder).unwrap();
+    assert_eq!(res.bids.len(), 2);
+    assert_eq!(res.bids[0], bid);
+}
+
+fn setup_contract(deps: DepsMut) {
+    let msg = InstantiateMsg {
+        operators: vec!["operator".to_string()],
+        trading_fee_percent: TRADING_FEE_PERCENT,
+        ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+        bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+    };
+    let info = mock_info(CREATOR, &[]);
+    let res = instantiate(deps, mock_env(), info, msg).unwrap();
+    assert_eq!(0, res.messages.len());
+}
+
+#[test]
+fn proper_initialization() {
+    let mut deps = mock_dependencies();
+
+    let msg = InstantiateMsg {
+        operators: vec!["operator".to_string()],
+        trading_fee_percent: TRADING_FEE_PERCENT,
+        ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+        bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+    };
+    let info = mock_info("creator", &coins(1000, NATIVE_DENOM));
+
+    // we can just call .unwrap() to assert this was a success
+    let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(0, res.messages.len());
+}
+
+#[test]
+fn try_set_bid() {
+    let mut deps = mock_dependencies();
+    setup_contract(deps.as_mut());
+
+    let broke = mock_info("broke", &[]);
+    let bidder = mock_info("bidder", &coins(1000, NATIVE_DENOM));
+
+    let set_bid_msg = ExecuteMsg::SetBid {
+        collection: COLLECTION.to_string(),
+        token_id: TOKEN_ID,
+        expires: Timestamp::from_seconds(0),
+    };
+
+    // Broke bidder calls Set Bid and gets an error
+    let err = execute(deps.as_mut(), mock_env(), broke, set_bid_msg).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::BidPaymentError(cw_utils::PaymentError::NoFunds {})
+    );
+
+    let set_bid_msg = ExecuteMsg::SetBid {
+        collection: COLLECTION.to_string(),
+        token_id: TOKEN_ID,
+        expires: mock_env().block.time.plus_seconds(MIN_EXPIRY + 1),
+    };
+
+    // Bidder calls SetBid before an Ask is set, so it should fail
+    let err = execute(deps.as_mut(), mock_env(), bidder, set_bid_msg).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::Std(StdError::NotFound {
+            kind: "sg_marketplace::state::Ask".to_string()
+        })
+    );
+}
+
+#[test]
+fn try_set_ask() {
+    let mut deps = mock_dependencies();
+    setup_contract(deps.as_mut());
+
+    let set_ask = ExecuteMsg::SetAsk {
+        collection: COLLECTION.to_string(),
+        token_id: TOKEN_ID,
+        price: coin(100, NATIVE_DENOM),
+        funds_recipient: None,
+        expires: Timestamp::from_seconds(
+            mock_env().block.time.plus_seconds(MIN_EXPIRY + 1).seconds(),
+        ),
+    };
+
+    // Reject if not called by the media owner
+    let not_allowed = mock_info("random", &[]);
+    let err = execute(deps.as_mut(), mock_env(), not_allowed, set_ask);
+    assert!(err.is_err());
+
+    // Reject wrong denom
+    let set_bad_ask = ExecuteMsg::SetAsk {
+        collection: COLLECTION.to_string(),
+        token_id: TOKEN_ID,
+        price: coin(100, "osmo".to_string()),
+        funds_recipient: None,
+        expires: Timestamp::from_seconds(
+            mock_env().block.time.plus_seconds(MIN_EXPIRY + 1).seconds(),
+        ),
+    };
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("creator", &[]),
+        set_bad_ask,
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::InvalidPrice {});
+}
+
+// TODO: Add hook tests

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -204,5 +204,3 @@ fn try_set_ask() {
     .unwrap_err();
     assert_eq!(err, ContractError::InvalidPrice {});
 }
-
-// TODO: Add hook tests

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -81,7 +81,7 @@ limit?: (number | null)
 [k: string]: unknown
 }
 } | {
-hooks: {
+sale_finalized_hooks: {
 [k: string]: unknown
 }
 })

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -80,4 +80,8 @@ collection: string
 limit?: (number | null)
 [k: string]: unknown
 }
+} | {
+hooks: {
+[k: string]: unknown
+}
 })

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -63,4 +63,21 @@ limit?: (number | null)
 params: {
 [k: string]: unknown
 }
+} | {
+collection_bid: {
+bidder: string
+collection: string
+[k: string]: unknown
+}
+} | {
+collection_bids_by_bidder: {
+bidder: string
+[k: string]: unknown
+}
+} | {
+collection_bids_sorted_by_price: {
+collection: string
+limit?: (number | null)
+[k: string]: unknown
+}
 })


### PR DESCRIPTION
Fixes #77 

Allows governance to set and remove hooks. Hooks are contracts which can be sent a pre-determined message to execute.
In this PR, a `SaleFinalizedHookMsg` is constructed and fired when a sale is finalized and if a hook exists.

This uses a `sg-controller` package which will be come in another PR and is in the stargaze-contracts repo.