### PR TITLE
Gracefully handle sales finalized hook failure and add sales price to hook msg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "sg-marketplace"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "sg-multi-test"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377a727f43cf3deb4c8dc1543534134f7cbd47578fb42a9adf2f35e433598daf"
+checksum = "68b2c20961ef0d92d3e071c923c2ceca525dddb4a0c57991c418f31d708c346f"
 dependencies = [
  "anyhow",
  "cosmwasm-std",

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -52,4 +52,4 @@ sg-controllers = "0.12.1"
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta8" }
 cw-multi-test = { version = "0.13.2" }
-sg-multi-test = "0.12.0"
+sg-multi-test = "0.13.0"

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sg-marketplace"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   "Shane Vitarana <s@noreply.publicawesome.com>",
   "Jake Hartnell <jake@publicawesome.com>",

--- a/contracts/marketplace/schema/sale_finalized_hook_msg.json
+++ b/contracts/marketplace/schema/sale_finalized_hook_msg.json
@@ -5,6 +5,7 @@
   "required": [
     "buyer",
     "collection",
+    "price",
     "seller",
     "token_id"
   ],
@@ -15,6 +16,9 @@
     "collection": {
       "type": "string"
     },
+    "price": {
+      "$ref": "#/definitions/Coin"
+    },
     "seller": {
       "type": "string"
     },
@@ -22,6 +26,27 @@
       "type": "integer",
       "format": "uint32",
       "minimum": 0.0
+    }
+  },
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
     }
   }
 }

--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -41,6 +41,9 @@ pub enum ContractError {
     #[error("Contract needs approval")]
     NeedsApproval {},
 
+    #[error("Unrecognised reply id: {0}")]
+    UnrecognisedReply(u64),
+
     #[error("{0}")]
     BidPaymentError(#[from] PaymentError),
 

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -8,7 +8,7 @@ use crate::state::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coin, to_binary, Addr, BankMsg, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Order,
+    coin, to_binary, Addr, BankMsg, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Order, Reply,
     StdResult, Storage, Timestamp, WasmMsg,
 };
 use cw2::set_contract_version;
@@ -17,7 +17,7 @@ use cw721_base::helpers::Cw721Contract;
 use cw_utils::{must_pay, nonpayable};
 use sg1::fair_burn;
 use sg721::msg::{CollectionInfoResponse, QueryMsg as Sg721QueryMsg};
-use sg_std::{CosmosMsg, Response, SubMsg, NATIVE_DENOM};
+use sg_std::{CosmosMsg, Response, StargazeQuery, SubMsg, NATIVE_DENOM};
 
 // Version info for migration info
 const CONTRACT_NAME: &str = "crates.io:sg-marketplace";
@@ -604,6 +604,15 @@ fn finalize_sale(
     })?;
 
     Ok((msgs, submsg))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(_deps: DepsMut, _env: Env, _msg: Reply) -> Result<Response, ContractError> {
+    let resp = Response::new().set_data(to_binary("sadf")?);
+
+    println!("in reply................");
+
+    Ok(resp)
 }
 
 /// Payout a bid

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -577,8 +577,12 @@ fn finalize_sale(
     price: Coin,
 ) -> StdResult<(Vec<CosmosMsg>, Vec<SubMsg>)> {
     // Payout bid
-    let mut msgs: Vec<CosmosMsg> =
-        payout(deps.as_ref(), collection.clone(), price, funds_recipient)?;
+    let mut msgs: Vec<CosmosMsg> = payout(
+        deps.as_ref(),
+        collection.clone(),
+        price.clone(),
+        funds_recipient,
+    )?;
 
     // Create transfer cw721 msg
     let cw721_transfer_msg = Cw721ExecuteMsg::TransferNft {
@@ -597,6 +601,7 @@ fn finalize_sale(
     let msg = SaleFinalizedHookMsg {
         collection: collection.to_string(),
         token_id,
+        price,
         seller: seller.to_string(),
         buyer: recipient.to_string(),
     };

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -622,7 +622,10 @@ fn finalize_sale(
 pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
     match msg.id {
         REPLY_SALE_FINALIZED_HOOK => {
-            Ok(Response::new().add_attribute("action", "sale_finalized_hook_failed"))
+            let res = Response::new()
+                .add_attribute("action", "sale_finalized_hook_failed")
+                .add_attribute("error", msg.result.unwrap_err());
+            Ok(res)
         }
         _ => Err(ContractError::UnrecognisedReply(msg.id)),
     }

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -224,15 +224,23 @@ pub struct CollectionBidsResponse {
 pub struct SaleFinalizedHookMsg {
     pub collection: String,
     pub token_id: u32,
+    pub price: Coin,
     pub seller: String,
     pub buyer: String,
 }
 
 impl SaleFinalizedHookMsg {
-    pub fn new(collection: String, token_id: u32, seller: String, buyer: String) -> Self {
+    pub fn new(
+        collection: String,
+        token_id: u32,
+        price: Coin,
+        seller: String,
+        buyer: String,
+    ) -> Self {
         SaleFinalizedHookMsg {
             collection,
             token_id,
+            price,
             seller,
             buyer,
         }

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -21,7 +21,8 @@ pub fn contract_nft_marketplace() -> Box<dyn Contract<StargazeMsgWrapper>> {
         crate::execute::instantiate,
         crate::query::query,
     )
-    .with_sudo(crate::sudo::sudo);
+    .with_sudo(crate::sudo::sudo)
+    .with_reply(crate::execute::reply);
     Box::new(contract)
 }
 
@@ -1493,12 +1494,9 @@ mod tests {
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
         };
         // Error because the "hook" contract is not deployed
-        let _err = router
+        let _ = router
             .execute_contract(bidder, marketplace, &set_bid_msg, &coins(100, NATIVE_DENOM))
             .unwrap_err();
-
-        // If the bid is accepted, the sale would be finalized
-        // assert_eq!("sale_finalized", res.events[1].attributes[1].value);
     }
 
     #[test]

--- a/types/contracts/marketplace/execute_msg.d.ts
+++ b/types/contracts/marketplace/execute_msg.d.ts
@@ -1,4 +1,4 @@
-import { Timestamp, Uint128 } from "./shared-types";
+import { Coin, Timestamp } from "./shared-types";
 
 export type ExecuteMsg = ({
 set_ask: {
@@ -63,9 +63,3 @@ token_id: number
 [k: string]: unknown
 }
 })
-
-export interface Coin {
-amount: Uint128
-denom: string
-[k: string]: unknown
-}

--- a/types/contracts/marketplace/sale_finalized_hook_msg.d.ts
+++ b/types/contracts/marketplace/sale_finalized_hook_msg.d.ts
@@ -1,6 +1,9 @@
+import { Coin } from "./shared-types";
+
 export interface SaleFinalizedHookMsg {
 buyer: string
 collection: string
+price: Coin
 seller: string
 token_id: number
 [k: string]: unknown

--- a/types/contracts/marketplace/shared-types.d.ts
+++ b/types/contracts/marketplace/shared-types.d.ts
@@ -70,3 +70,8 @@ export interface Bid {
     price: Uint128;
     token_id: number;
 }
+export interface Coin {
+    [k: string]: unknown;
+    amount: Uint128;
+    denom: string;
+}


### PR DESCRIPTION
Fixes #89 

If there's an error in the sales finalized hook, the reply is handled which logs the error as an event and allows the transaction to complete, performing the transfer. If an unrecognized reply comes in, an error is thrown and the transaction is rolled back.