### PR TITLE
Update schema to support cosmwasm-typescript-gen

### DIFF
--- a/contracts/marketplace/examples/schema.rs
+++ b/contracts/marketplace/examples/schema.rs
@@ -1,7 +1,7 @@
-use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 use sg_marketplace::msg::{
     AskCountResponse, AsksResponse, BidResponse, BidsResponse, CollectionBidResponse,
-    CollectionsResponse, CurrentAskResponse, ExecuteMsg, InstantiateMsg, ParamResponse, QueryMsg,
+    CollectionsResponse, CurrentAskResponse, ExecuteMsg, InstantiateMsg, ParamsResponse, QueryMsg,
     SaleFinalizedHookMsg, SudoMsg,
 };
 use sg_marketplace::MarketplaceContract;
@@ -19,13 +19,47 @@ fn main() {
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(SudoMsg), &out_dir);
-    export_schema(&schema_for!(SaleFinalizedHookMsg), &out_dir);
     export_schema(&schema_for!(AsksResponse), &out_dir);
     export_schema(&schema_for!(BidResponse), &out_dir);
     export_schema(&schema_for!(BidsResponse), &out_dir);
     export_schema(&schema_for!(CollectionsResponse), &out_dir);
     export_schema(&schema_for!(CurrentAskResponse), &out_dir);
     export_schema(&schema_for!(AskCountResponse), &out_dir);
-    export_schema(&schema_for!(ParamResponse), &out_dir);
+    export_schema(&schema_for!(ParamsResponse), &out_dir);
     export_schema(&schema_for!(CollectionBidResponse), &out_dir);
+
+    // cosmwasm-typescript-gen expects the query return type as QueryNameResponse
+    // Here we map query resonses to the correct name
+    export_schema_with_title(&schema_for!(AsksResponse), &out_dir, "AsksBySellerResponse");
+    export_schema_with_title(
+        &schema_for!(AsksResponse),
+        &out_dir,
+        "AsksSortedByPriceResponse",
+    );
+    export_schema_with_title(&schema_for!(BidsResponse), &out_dir, "BidsByBidderResponse");
+    export_schema_with_title(
+        &schema_for!(BidsResponse),
+        &out_dir,
+        "BidsSortedByPriceResponse",
+    );
+    export_schema_with_title(
+        &schema_for!(BidsResponse),
+        &out_dir,
+        "CollectionBidsByBidderResponse",
+    );
+    export_schema_with_title(
+        &schema_for!(BidsResponse),
+        &out_dir,
+        "CollectionBidsSortedByPriceResponse",
+    );
+    export_schema_with_title(
+        &schema_for!(CollectionsResponse),
+        &out_dir,
+        "ListedCollectionsResponse",
+    );
+    export_schema_with_title(
+        &schema_for!(SaleFinalizedHookMsg),
+        &out_dir,
+        "SaleFinalizedHooksResponse",
+    );
 }

--- a/contracts/marketplace/schema/asks_by_seller_response.json
+++ b/contracts/marketplace/schema/asks_by_seller_response.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AsksBySellerResponse",
+  "type": "object",
+  "required": [
+    "asks"
+  ],
+  "properties": {
+    "asks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Ask"
+      }
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Ask": {
+      "description": "Represents an ask on the marketplace",
+      "type": "object",
+      "required": [
+        "active",
+        "collection",
+        "expires",
+        "price",
+        "seller",
+        "token_id"
+      ],
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "collection": {
+          "$ref": "#/definitions/Addr"
+        },
+        "expires": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "funds_recipient": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "seller": {
+          "$ref": "#/definitions/Addr"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/asks_sorted_by_price_response.json
+++ b/contracts/marketplace/schema/asks_sorted_by_price_response.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AsksSortedByPriceResponse",
+  "type": "object",
+  "required": [
+    "asks"
+  ],
+  "properties": {
+    "asks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Ask"
+      }
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Ask": {
+      "description": "Represents an ask on the marketplace",
+      "type": "object",
+      "required": [
+        "active",
+        "collection",
+        "expires",
+        "price",
+        "seller",
+        "token_id"
+      ],
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "collection": {
+          "$ref": "#/definitions/Addr"
+        },
+        "expires": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "funds_recipient": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "seller": {
+          "$ref": "#/definitions/Addr"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/bids_by_bidder_response.json
+++ b/contracts/marketplace/schema/bids_by_bidder_response.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BidsByBidderResponse",
+  "type": "object",
+  "required": [
+    "bids"
+  ],
+  "properties": {
+    "bids": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Bid"
+      }
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Bid": {
+      "description": "Represents a bid (offer) on the marketplace",
+      "type": "object",
+      "required": [
+        "bidder",
+        "collection",
+        "expires",
+        "price",
+        "token_id"
+      ],
+      "properties": {
+        "bidder": {
+          "$ref": "#/definitions/Addr"
+        },
+        "collection": {
+          "$ref": "#/definitions/Addr"
+        },
+        "expires": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/bids_sorted_by_price_response.json
+++ b/contracts/marketplace/schema/bids_sorted_by_price_response.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BidsSortedByPriceResponse",
+  "type": "object",
+  "required": [
+    "bids"
+  ],
+  "properties": {
+    "bids": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Bid"
+      }
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Bid": {
+      "description": "Represents a bid (offer) on the marketplace",
+      "type": "object",
+      "required": [
+        "bidder",
+        "collection",
+        "expires",
+        "price",
+        "token_id"
+      ],
+      "properties": {
+        "bidder": {
+          "$ref": "#/definitions/Addr"
+        },
+        "collection": {
+          "$ref": "#/definitions/Addr"
+        },
+        "expires": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/collection_bids_by_bidder_response.json
+++ b/contracts/marketplace/schema/collection_bids_by_bidder_response.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CollectionBidsByBidderResponse",
+  "type": "object",
+  "required": [
+    "bids"
+  ],
+  "properties": {
+    "bids": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Bid"
+      }
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Bid": {
+      "description": "Represents a bid (offer) on the marketplace",
+      "type": "object",
+      "required": [
+        "bidder",
+        "collection",
+        "expires",
+        "price",
+        "token_id"
+      ],
+      "properties": {
+        "bidder": {
+          "$ref": "#/definitions/Addr"
+        },
+        "collection": {
+          "$ref": "#/definitions/Addr"
+        },
+        "expires": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/collection_bids_sorted_by_price_response.json
+++ b/contracts/marketplace/schema/collection_bids_sorted_by_price_response.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CollectionBidsSortedByPriceResponse",
+  "type": "object",
+  "required": [
+    "bids"
+  ],
+  "properties": {
+    "bids": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Bid"
+      }
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Bid": {
+      "description": "Represents a bid (offer) on the marketplace",
+      "type": "object",
+      "required": [
+        "bidder",
+        "collection",
+        "expires",
+        "price",
+        "token_id"
+      ],
+      "properties": {
+        "bidder": {
+          "$ref": "#/definitions/Addr"
+        },
+        "collection": {
+          "$ref": "#/definitions/Addr"
+        },
+        "expires": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/listed_collections_response.json
+++ b/contracts/marketplace/schema/listed_collections_response.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ListedCollectionsResponse",
+  "type": "object",
+  "required": [
+    "collections"
+  ],
+  "properties": {
+    "collections": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Addr"
+      }
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/params_response.json
+++ b/contracts/marketplace/schema/params_response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ParamResponse",
+  "title": "ParamsResponse",
   "type": "object",
   "required": [
     "params"

--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -289,7 +289,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Get the config for the contract Return type: `ParamResponse`",
+      "description": "Get the config for the contract Return type: `ParamsResponse`",
       "type": "object",
       "required": [
         "params"

--- a/contracts/marketplace/schema/sale_finalized_hooks_response.json
+++ b/contracts/marketplace/schema/sale_finalized_hooks_response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "SaleFinalizedHookMsg",
+  "title": "SaleFinalizedHooksResponse",
   "type": "object",
   "required": [
     "buyer",

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -152,7 +152,7 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     /// Get the config for the contract
-    /// Return type: `ParamResponse`
+    /// Return type: `ParamsResponse`
     Params {},
     /// Get data for a specific collection bid
     /// Return type: `CollectionBidResponse`
@@ -205,7 +205,7 @@ pub struct BidsResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ParamResponse {
+pub struct ParamsResponse {
     pub params: SudoParams,
 }
 

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -37,7 +37,7 @@ pub fn contract_sg721() -> Box<dyn Contract<StargazeMsgWrapper>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::msg::{AsksResponse, BidResponse, CollectionsResponse, ParamResponse, SudoMsg};
+    use crate::msg::{AsksResponse, BidResponse, CollectionsResponse, ParamsResponse, SudoMsg};
     use crate::state::Bid;
 
     use super::*;
@@ -1409,7 +1409,7 @@ mod tests {
         assert!(res.is_ok());
 
         let query_params_msg = QueryMsg::Params {};
-        let res: ParamResponse = router
+        let res: ParamsResponse = router
             .wrap()
             .query_wasm_smart(marketplace, &query_params_msg)
             .unwrap();

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -1,7 +1,7 @@
 use crate::msg::{
     AskCountResponse, AsksResponse, BidResponse, Bidder, BidsResponse, Collection,
     CollectionBidResponse, CollectionBidsResponse, CollectionsResponse, CurrentAskResponse,
-    ParamResponse, QueryMsg,
+    ParamsResponse, QueryMsg,
 };
 use crate::state::{
     ask_key, asks, bids, collection_bid_key, collection_bids, TokenId, SALE_FINALIZED_HOOKS,
@@ -95,10 +95,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
-pub fn query_params(deps: Deps) -> StdResult<ParamResponse> {
+pub fn query_params(deps: Deps) -> StdResult<ParamsResponse> {
     let config = SUDO_PARAMS.load(deps.storage)?;
 
-    Ok(ParamResponse { params: config })
+    Ok(ParamsResponse { params: config })
 }
 
 pub fn query_asks(

--- a/types/contracts/marketplace/param_response.d.ts
+++ b/types/contracts/marketplace/param_response.d.ts
@@ -1,13 +1,13 @@
 import { Addr } from "./shared-types";
 
-export interface ParamResponse {
-params: SudoParams
-[k: string]: unknown
+export interface ParamsResponse {
+  params: SudoParams;
+  [k: string]: unknown;
 }
 export interface SudoParams {
-ask_expiry: [number, number]
-bid_expiry: [number, number]
-operators: Addr[]
-trading_fee_percent: number
-[k: string]: unknown
+  ask_expiry: [number, number];
+  bid_expiry: [number, number];
+  operators: Addr[];
+  trading_fee_percent: number;
+  [k: string]: unknown;
 }


### PR DESCRIPTION
Updates the schema so that it can work with [cosmwasm-typescript-gen](https://github.com/pyramation/cosmwasm-typescript-gen).

Output: https://gist.github.com/JakeHartnell/2119f53f918fb0d4f7f294b042b08261