### PR TITLE
Idomatic expiry struct

### DIFF
--- a/contracts/marketplace/schema/instantiate_msg.json
+++ b/contracts/marketplace/schema/instantiate_msg.json
@@ -11,39 +11,19 @@
   "properties": {
     "ask_expiry": {
       "description": "Valid time range for Asks (min, max) in seconds",
-      "type": "array",
-      "items": [
+      "allOf": [
         {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
+          "$ref": "#/definitions/ExpiryRange"
         }
-      ],
-      "maxItems": 2,
-      "minItems": 2
+      ]
     },
     "bid_expiry": {
       "description": "Valid time range for Bids (min, max) in seconds",
-      "type": "array",
-      "items": [
+      "allOf": [
         {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
+          "$ref": "#/definitions/ExpiryRange"
         }
-      ],
-      "maxItems": 2,
-      "minItems": 2
+      ]
     },
     "operators": {
       "description": "Operators are entites that are responsible for maintaining the active state of Asks. They listen to NFT transfer events, and update the active state of Asks.",
@@ -63,6 +43,27 @@
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
+    }
+  },
+  "definitions": {
+    "ExpiryRange": {
+      "type": "object",
+      "required": [
+        "max",
+        "min"
+      ],
+      "properties": {
+        "max": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "min": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     }
   }
 }

--- a/contracts/marketplace/schema/params_response.json
+++ b/contracts/marketplace/schema/params_response.json
@@ -19,6 +19,25 @@
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
+    "ExpiryRange": {
+      "type": "object",
+      "required": [
+        "max",
+        "min"
+      ],
+      "properties": {
+        "max": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "min": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
     "SudoParams": {
       "type": "object",
       "required": [
@@ -30,39 +49,19 @@
       "properties": {
         "ask_expiry": {
           "description": "Valid time range for Asks (min, max) in seconds",
-          "type": "array",
-          "items": [
+          "allOf": [
             {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
+              "$ref": "#/definitions/ExpiryRange"
             }
-          ],
-          "maxItems": 2,
-          "minItems": 2
+          ]
         },
         "bid_expiry": {
           "description": "Valid time range for Bids (min, max) in seconds",
-          "type": "array",
-          "items": [
+          "allOf": [
             {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
+              "$ref": "#/definitions/ExpiryRange"
             }
-          ],
-          "maxItems": 2,
-          "minItems": 2
+          ]
         },
         "operators": {
           "description": "Operators are entites that are responsible for maintaining the active state of Asks They listen to NFT transfer events, and update the active state of Asks",

--- a/contracts/marketplace/schema/sudo_msg.json
+++ b/contracts/marketplace/schema/sudo_msg.json
@@ -13,44 +13,24 @@
           "type": "object",
           "properties": {
             "ask_expiry": {
-              "type": [
-                "array",
-                "null"
-              ],
-              "items": [
+              "anyOf": [
                 {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
+                  "$ref": "#/definitions/ExpiryRange"
                 },
                 {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
+                  "type": "null"
                 }
-              ],
-              "maxItems": 2,
-              "minItems": 2
+              ]
             },
             "bid_expiry": {
-              "type": [
-                "array",
-                "null"
-              ],
-              "items": [
+              "anyOf": [
                 {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
+                  "$ref": "#/definitions/ExpiryRange"
                 },
                 {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
+                  "type": "null"
                 }
-              ],
-              "maxItems": 2,
-              "minItems": 2
+              ]
             },
             "operators": {
               "type": [
@@ -158,5 +138,26 @@
       },
       "additionalProperties": false
     }
-  ]
+  ],
+  "definitions": {
+    "ExpiryRange": {
+      "type": "object",
+      "required": [
+        "max",
+        "min"
+      ],
+      "properties": {
+        "max": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "min": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    }
+  }
 }

--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -3,6 +3,8 @@ use cw_utils::PaymentError;
 use sg_controllers::HookError;
 use thiserror::Error;
 
+use crate::helpers::ExpiryRangeError;
+
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
@@ -49,4 +51,7 @@ pub enum ContractError {
 
     #[error("{0}")]
     Hook(#[from] HookError),
+
+    #[error("{0}")]
+    ExpiryRange(#[from] ExpiryRangeError),
 }

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -166,7 +166,7 @@ pub fn execute_set_ask(
     price_validate(&price)?;
 
     let params = SUDO_PARAMS.load(deps.storage)?;
-    expires_validate(&env, expires, params.ask_expiry)?;
+    params.ask_expiry.is_valid(&env.block, expires)?;
 
     // Only the media onwer can call this
     let owner_of_response = only_owner(deps.as_ref(), &info, collection.clone(), token_id)?;

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -321,7 +321,7 @@ pub fn execute_set_bid(
     let bid_price = must_pay(&info, NATIVE_DENOM)?;
 
     let params = SUDO_PARAMS.load(deps.storage)?;
-    expires_validate(&env, expires, params.bid_expiry)?;
+    params.bid_expiry.is_valid(&env.block, expires)?;
 
     let bidder = info.sender;
     let mut res = Response::new();
@@ -498,7 +498,7 @@ pub fn execute_set_collection_bid(
     let price = must_pay(&info, NATIVE_DENOM)?;
 
     let params = SUDO_PARAMS.load(deps.storage)?;
-    expires_validate(&env, expires, params.bid_expiry)?;
+    params.bid_expiry.is_valid(&env.block, expires)?;
 
     let bidder = info.sender;
     let mut res = Response::new();
@@ -719,20 +719,6 @@ fn payout(
     }
 
     Ok(msgs)
-}
-
-fn expires_validate(
-    env: &Env,
-    expires: Timestamp,
-    expiry: (u64, u64),
-) -> Result<(), ContractError> {
-    if expires <= env.block.time.plus_seconds(expiry.0)
-        || expires > env.block.time.plus_seconds(expiry.1)
-    {
-        return Err(ContractError::InvalidExpiration {});
-    }
-
-    Ok(())
 }
 
 fn price_validate(price: &Coin) -> Result<(), ContractError> {

--- a/contracts/marketplace/src/helpers.rs
+++ b/contracts/marketplace/src/helpers.rs
@@ -45,8 +45,8 @@ pub enum ExpiryRangeError {
 pub struct ExpiryRange(pub u64, pub u64);
 
 impl ExpiryRange {
-    pub fn new(min: u64, max: u64) -> Self {
-        ExpiryRange(min, max)
+    pub fn new(range: (u64, u64)) -> Self {
+        ExpiryRange(range.0, range.1)
     }
 
     /// Validates if given expires time is within the allowable range

--- a/contracts/marketplace/src/helpers.rs
+++ b/contracts/marketplace/src/helpers.rs
@@ -1,9 +1,9 @@
-use cosmwasm_std::{to_binary, Addr, Api, StdResult, WasmMsg};
+use crate::msg::ExecuteMsg;
+use cosmwasm_std::{to_binary, Addr, Api, BlockInfo, StdError, StdResult, Timestamp, WasmMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sg_std::CosmosMsg;
-
-use crate::msg::ExecuteMsg;
+use thiserror::Error;
 
 /// MarketplaceContract is a wrapper around Addr that provides a lot of helpers
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -30,4 +30,32 @@ pub fn map_validate(api: &dyn Api, addresses: &[String]) -> StdResult<Vec<Addr>>
         .iter()
         .map(|addr| api.addr_validate(addr))
         .collect()
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ExpiryRangeError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Invalid expiration range")]
+    InvalidExpirationRange {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ExpiryRange(pub u64, pub u64);
+
+impl ExpiryRange {
+    pub fn new(min: u64, max: u64) -> Self {
+        ExpiryRange(min, max)
+    }
+
+    /// Validates if given expires time is within the allowable range
+    pub fn is_valid(&self, block: &BlockInfo, expires: Timestamp) -> Result<(), ExpiryRangeError> {
+        let now = block.time;
+        if !(expires > now.plus_seconds(self.0) && expires <= now.plus_seconds(self.1)) {
+            return Err(ExpiryRangeError::InvalidExpirationRange {});
+        }
+
+        Ok(())
+    }
 }

--- a/contracts/marketplace/src/helpers.rs
+++ b/contracts/marketplace/src/helpers.rs
@@ -42,17 +42,20 @@ pub enum ExpiryRangeError {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ExpiryRange(pub u64, pub u64);
+pub struct ExpiryRange {
+    pub min: u64,
+    pub max: u64,
+}
 
 impl ExpiryRange {
-    pub fn new(range: (u64, u64)) -> Self {
-        ExpiryRange(range.0, range.1)
+    pub fn new(min: u64, max: u64) -> Self {
+        ExpiryRange { min, max }
     }
 
     /// Validates if given expires time is within the allowable range
     pub fn is_valid(&self, block: &BlockInfo, expires: Timestamp) -> Result<(), ExpiryRangeError> {
         let now = block.time;
-        if !(expires > now.plus_seconds(self.0) && expires <= now.plus_seconds(self.1)) {
+        if !(expires > now.plus_seconds(self.min) && expires <= now.plus_seconds(self.max)) {
             return Err(ExpiryRangeError::InvalidExpirationRange {});
         }
 

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -89,8 +89,8 @@ pub enum SudoMsg {
     /// Can only be called by governance
     UpdateParams {
         trading_fee_basis_points: Option<u64>,
-        ask_expiry: Option<(u64, u64)>,
-        bid_expiry: Option<(u64, u64)>,
+        ask_expiry: Option<ExpiryRange>,
+        bid_expiry: Option<ExpiryRange>,
         operators: Option<Vec<String>>,
     },
     /// Add a new hook to be informed of all trades

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -1,4 +1,7 @@
-use crate::state::{Ask, Bid, CollectionBid, SudoParams, TokenId};
+use crate::{
+    helpers::ExpiryRange,
+    state::{Ask, Bid, CollectionBid, SudoParams, TokenId},
+};
 use cosmwasm_std::{to_binary, Addr, Binary, Coin, StdResult, Timestamp, WasmMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -11,7 +14,7 @@ pub struct InstantiateMsg {
     pub trading_fee_basis_points: u64,
     /// Valid time range for Asks
     /// (min, max) in seconds
-    pub ask_expiry: (u64, u64),
+    pub ask_expiry: ExpiryRange,
     /// Valid time range for Bids
     /// (min, max) in seconds
     pub bid_expiry: (u64, u64),

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -17,7 +17,7 @@ pub struct InstantiateMsg {
     pub ask_expiry: ExpiryRange,
     /// Valid time range for Bids
     /// (min, max) in seconds
-    pub bid_expiry: (u64, u64),
+    pub bid_expiry: ExpiryRange,
     /// Operators are entites that are responsible for maintaining the active state of Asks.
     /// They listen to NFT transfer events, and update the active state of Asks.
     pub operators: Vec<String>,

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -37,6 +37,7 @@ pub fn contract_sg721() -> Box<dyn Contract<StargazeMsgWrapper>> {
 
 #[cfg(test)]
 mod tests {
+    use crate::helpers::ExpiryRange;
     use crate::msg::{AsksResponse, BidResponse, CollectionsResponse, ParamsResponse, SudoMsg};
     use crate::state::Bid;
 
@@ -66,8 +67,8 @@ mod tests {
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-            ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+            ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+            bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
             sales_finalized_hook: None,
         };
         let nft_marketplace_addr = router
@@ -1295,8 +1296,8 @@ mod tests {
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-            ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+            ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+            bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
             sales_finalized_hook: None,
         };
         let nft_marketplace_addr = router
@@ -1445,7 +1446,7 @@ mod tests {
             .query_wasm_smart(marketplace, &query_params_msg)
             .unwrap();
         assert_eq!(res.params.trading_fee_basis_points, Decimal::percent(5));
-        assert_eq!(res.params.ask_expiry, (1, 2));
+        assert_eq!(res.params.ask_expiry, ExpiryRange(1, 2));
         assert_eq!(res.params.operators, vec!["operator".to_string()]);
     }
 
@@ -1493,8 +1494,8 @@ mod tests {
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-            ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+            ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+            bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
             sales_finalized_hook: Some("hook".to_string()),
         };
         let marketplace = router

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -67,8 +67,8 @@ mod tests {
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-            ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+            ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
+            bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             sales_finalized_hook: None,
         };
         let nft_marketplace_addr = router
@@ -1296,8 +1296,8 @@ mod tests {
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-            ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+            ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
+            bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             sales_finalized_hook: None,
         };
         let nft_marketplace_addr = router
@@ -1433,7 +1433,7 @@ mod tests {
 
         let update_config_msg = SudoMsg::UpdateParams {
             trading_fee_basis_points: Some(5),
-            ask_expiry: Some((1, 2)),
+            ask_expiry: Some(ExpiryRange::new(1, 2)),
             bid_expiry: None,
             operators: Some(vec!["operator".to_string()]),
         };
@@ -1446,7 +1446,7 @@ mod tests {
             .query_wasm_smart(marketplace, &query_params_msg)
             .unwrap();
         assert_eq!(res.params.trading_fee_basis_points, Decimal::percent(5));
-        assert_eq!(res.params.ask_expiry, ExpiryRange(1, 2));
+        assert_eq!(res.params.ask_expiry, ExpiryRange::new(1, 2));
         assert_eq!(res.params.operators, vec!["operator".to_string()]);
     }
 
@@ -1494,8 +1494,8 @@ mod tests {
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-            ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
-            bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+            ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
+            bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             sales_finalized_hook: Some("hook".to_string()),
         };
         let marketplace = router

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, BlockInfo, Decimal, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, MultiIndex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ pub struct SudoParams {
     pub ask_expiry: ExpiryRange,
     /// Valid time range for Bids
     /// (min, max) in seconds
-    pub bid_expiry: (u64, u64),
+    pub bid_expiry: ExpiryRange,
     /// Operators are entites that are responsible for maintaining the active state of Asks
     /// They listen to NFT transfer events, and update the active state of Asks
     pub operators: Vec<Addr>,

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -4,6 +4,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sg_controllers::Hooks;
 
+use crate::helpers::ExpiryRange;
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct SudoParams {
     /// Fair Burn fee for winning bids
@@ -11,28 +13,13 @@ pub struct SudoParams {
     pub trading_fee_basis_points: Decimal,
     /// Valid time range for Asks
     /// (min, max) in seconds
-    pub ask_expiry: (u64, u64),
+    pub ask_expiry: ExpiryRange,
     /// Valid time range for Bids
     /// (min, max) in seconds
     pub bid_expiry: (u64, u64),
     /// Operators are entites that are responsible for maintaining the active state of Asks
     /// They listen to NFT transfer events, and update the active state of Asks
     pub operators: Vec<Addr>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ExpiryRange(pub u64, pub u64);
-
-impl ExpiryRange {
-    pub fn new(min: u64, max: u64) -> Self {
-        ExpiryRange(min, max)
-    }
-
-    /// Validates if given expires time is within the allowable range
-    pub fn is_valid(&self, block: &BlockInfo, expires: Timestamp) -> bool {
-        let now = block.time;
-        expires > now.plus_seconds(self.0) && expires <= now.plus_seconds(self.1)
-    }
 }
 
 pub const SUDO_PARAMS: Item<SudoParams> = Item::new("sudo_params");

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -21,20 +21,17 @@ pub struct SudoParams {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ExpiryRange {
-    pub min: u64,
-    pub max: u64,
-}
+pub struct ExpiryRange(pub u64, pub u64);
 
 impl ExpiryRange {
     pub fn new(min: u64, max: u64) -> Self {
-        ExpiryRange { min, max }
+        ExpiryRange(min, max)
     }
 
     /// Validates if given expires time is within the allowable range
     pub fn is_valid(&self, block: &BlockInfo, expires: Timestamp) -> bool {
         let now = block.time;
-        expires > now.plus_seconds(self.min) && expires <= now.plus_seconds(self.max)
+        expires > now.plus_seconds(self.0) && expires <= now.plus_seconds(self.1)
     }
 }
 

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
+use cosmwasm_std::{Addr, BlockInfo, Decimal, Timestamp, Uint128};
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, MultiIndex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -18,6 +18,24 @@ pub struct SudoParams {
     /// Operators are entites that are responsible for maintaining the active state of Asks
     /// They listen to NFT transfer events, and update the active state of Asks
     pub operators: Vec<Addr>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ExpiryRange {
+    pub min: u64,
+    pub max: u64,
+}
+
+impl ExpiryRange {
+    pub fn new(min: u64, max: u64) -> Self {
+        ExpiryRange { min, max }
+    }
+
+    /// Validates if given expires time is within the allowable range
+    pub fn is_valid(&self, block: &BlockInfo, expires: Timestamp) -> bool {
+        let now = block.time;
+        expires > now.plus_seconds(self.min) && expires <= now.plus_seconds(self.max)
+    }
 }
 
 pub const SUDO_PARAMS: Item<SudoParams> = Item::new("sudo_params");

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -39,8 +39,8 @@ pub fn sudo_update_params(
     deps: DepsMut,
     _env: Env,
     trading_fee: Option<u64>,
-    ask_expiry: Option<(u64, u64)>,
-    bid_expiry: Option<(u64, u64)>,
+    ask_expiry: Option<ExpiryRange>,
+    bid_expiry: Option<ExpiryRange>,
     operators: Option<Vec<String>>,
 ) -> Result<Response, ContractError> {
     let mut params = SUDO_PARAMS.load(deps.storage)?;
@@ -48,19 +48,11 @@ pub fn sudo_update_params(
     params.trading_fee_basis_points = trading_fee
         .map(Decimal::percent)
         .unwrap_or(params.trading_fee_basis_points);
-
-    params.ask_expiry = ask_expiry
-        .map(ExpiryRange::new)
-        .unwrap_or(params.ask_expiry);
-
-    params.bid_expiry = bid_expiry
-        .map(ExpiryRange::new)
-        .unwrap_or(params.bid_expiry);
-
+    params.ask_expiry = ask_expiry.unwrap_or(params.ask_expiry);
+    params.bid_expiry = bid_expiry.unwrap_or(params.bid_expiry);
     if let Some(operators) = operators {
         params.operators = map_validate(deps.api, &operators)?;
     }
-
     SUDO_PARAMS.save(deps.storage, &params)?;
 
     Ok(Response::new().add_attribute("action", "update_params"))

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -3,6 +3,7 @@ use std::vec;
 
 use crate::error::ContractError;
 use crate::execute::{execute, instantiate};
+use crate::helpers::ExpiryRange;
 use crate::msg::{ExecuteMsg, InstantiateMsg};
 use crate::query::{query_ask_count, query_asks_by_seller, query_bids_by_bidder};
 use crate::state::{ask_key, asks, bid_key, bids, Ask, Bid};
@@ -104,8 +105,8 @@ fn setup_contract(deps: DepsMut) {
     let msg = InstantiateMsg {
         operators: vec!["operator".to_string()],
         trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-        ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-        bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+        ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+        bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
         sales_finalized_hook: None,
     };
     let info = mock_info(CREATOR, &[]);
@@ -120,8 +121,8 @@ fn proper_initialization() {
     let msg = InstantiateMsg {
         operators: vec!["operator".to_string()],
         trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-        ask_expiry: (MIN_EXPIRY, MAX_EXPIRY),
-        bid_expiry: (MIN_EXPIRY, MAX_EXPIRY),
+        ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+        bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
         sales_finalized_hook: None,
     };
     let info = mock_info("creator", &coins(1000, NATIVE_DENOM));

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -105,8 +105,8 @@ fn setup_contract(deps: DepsMut) {
     let msg = InstantiateMsg {
         operators: vec!["operator".to_string()],
         trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-        ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
-        bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+        ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
+        bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         sales_finalized_hook: None,
     };
     let info = mock_info(CREATOR, &[]);
@@ -121,8 +121,8 @@ fn proper_initialization() {
     let msg = InstantiateMsg {
         operators: vec!["operator".to_string()],
         trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
-        ask_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
-        bid_expiry: ExpiryRange(MIN_EXPIRY, MAX_EXPIRY),
+        ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
+        bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         sales_finalized_hook: None,
     };
     let info = mock_info("creator", &coins(1000, NATIVE_DENOM));

--- a/types/contracts/marketplace/ask_response.d.ts
+++ b/types/contracts/marketplace/ask_response.d.ts
@@ -1,0 +1,6 @@
+import { Ask } from "./shared-types";
+
+export interface AskResponse {
+ask?: (Ask | null)
+[k: string]: unknown
+}

--- a/types/contracts/marketplace/index.ts
+++ b/types/contracts/marketplace/index.ts
@@ -1,4 +1,5 @@
 export * from "./ask_count_response";
+export * from "./ask_response";
 // dedup emptied this file
 // export * from "./ask";
 export * from "./asks_by_seller_response";

--- a/types/contracts/marketplace/instantiate_msg.d.ts
+++ b/types/contracts/marketplace/instantiate_msg.d.ts
@@ -1,12 +1,14 @@
+import { ExpiryRange } from "./shared-types";
+
 export interface InstantiateMsg {
 /**
  * Valid time range for Asks (min, max) in seconds
  */
-ask_expiry: [number, number]
+ask_expiry: ExpiryRange
 /**
  * Valid time range for Bids (min, max) in seconds
  */
-bid_expiry: [number, number]
+bid_expiry: ExpiryRange
 /**
  * Operators are entites that are responsible for maintaining the active state of Asks. They listen to NFT transfer events, and update the active state of Asks.
  */

--- a/types/contracts/marketplace/params_response.d.ts
+++ b/types/contracts/marketplace/params_response.d.ts
@@ -1,4 +1,5 @@
-import { Addr } from "./shared-types";
+import { Addr, ExpiryRange } from "./shared-types";
+
 /**
  * A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0
  * 
@@ -14,11 +15,11 @@ export interface SudoParams {
 /**
  * Valid time range for Asks (min, max) in seconds
  */
-ask_expiry: [number, number]
+ask_expiry: ExpiryRange
 /**
  * Valid time range for Bids (min, max) in seconds
  */
-bid_expiry: [number, number]
+bid_expiry: ExpiryRange
 /**
  * Operators are entites that are responsible for maintaining the active state of Asks They listen to NFT transfer events, and update the active state of Asks
  */

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -1,7 +1,13 @@
 import { Uint128 } from "./shared-types";
 
 export type QueryMsg = ({
-current_ask: {
+collections: {
+limit?: (number | null)
+start_after?: (string | null)
+[k: string]: unknown
+}
+} | {
+ask: {
 collection: string
 token_id: number
 [k: string]: unknown
@@ -38,12 +44,6 @@ seller: string
 [k: string]: unknown
 }
 } | {
-listed_collections: {
-limit?: (number | null)
-start_after?: (string | null)
-[k: string]: unknown
-}
-} | {
 bid: {
 bidder: string
 collection: string
@@ -71,10 +71,6 @@ order_asc: boolean
 [k: string]: unknown
 }
 } | {
-params: {
-[k: string]: unknown
-}
-} | {
 collection_bid: {
 bidder: string
 collection: string
@@ -93,11 +89,15 @@ order_asc: boolean
 [k: string]: unknown
 }
 } | {
+ask_hooks: {
+[k: string]: unknown
+}
+} | {
 sale_finalized_hooks: {
 [k: string]: unknown
 }
 } | {
-ask_hooks: {
+params: {
 [k: string]: unknown
 }
 })

--- a/types/contracts/marketplace/shared-types.d.ts
+++ b/types/contracts/marketplace/shared-types.d.ts
@@ -75,3 +75,8 @@ export interface Coin {
     amount: Uint128;
     denom: string;
 }
+export interface ExpiryRange {
+    [k: string]: unknown;
+    max: number;
+    min: number;
+}

--- a/types/contracts/marketplace/sudo_msg.d.ts
+++ b/types/contracts/marketplace/sudo_msg.d.ts
@@ -1,7 +1,9 @@
+import { ExpiryRange } from "./shared-types";
+
 export type SudoMsg = ({
 update_params: {
-ask_expiry?: ([number, number] | null)
-bid_expiry?: ([number, number] | null)
+ask_expiry?: (ExpiryRange | null)
+bid_expiry?: (ExpiryRange | null)
 operators?: (string[] | null)
 trading_fee_basis_points?: (number | null)
 [k: string]: unknown


### PR DESCRIPTION
Adds a bit more type safety around bid/ask expiry ranges in a more idomatic Rust style. It makes the message and JSON more self-describing. Also removes using a tuple in messages which some clients may have issues with. 

I am on the fence though since it does make everything a bit more verbose.