### PR TITLE
Fix `Offset` price type

### DIFF
--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -93,7 +93,7 @@
             "start_after": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Ask"
+                  "$ref": "#/definitions/Offset"
                 },
                 {
                   "type": "null"
@@ -132,7 +132,7 @@
             "start_before": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Ask"
+                  "$ref": "#/definitions/Offset"
                 },
                 {
                   "type": "null"
@@ -461,46 +461,16 @@
     }
   ],
   "definitions": {
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
-    "Ask": {
-      "description": "Represents an ask on the marketplace",
+    "Offset": {
+      "description": "Offsets for pagination",
       "type": "object",
       "required": [
-        "active",
-        "collection",
-        "expires",
         "price",
-        "seller",
         "token_id"
       ],
       "properties": {
-        "active": {
-          "type": "boolean"
-        },
-        "collection": {
-          "$ref": "#/definitions/Addr"
-        },
-        "expires": {
-          "$ref": "#/definitions/Timestamp"
-        },
-        "funds_recipient": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "price": {
           "$ref": "#/definitions/Uint128"
-        },
-        "seller": {
-          "$ref": "#/definitions/Addr"
         },
         "token_id": {
           "type": "integer",
@@ -509,20 +479,8 @@
         }
       }
     },
-    "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Uint64"
-        }
-      ]
-    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
-      "type": "string"
-    },
-    "Uint64": {
-      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
     }
   }

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -1,5 +1,5 @@
-use crate::state::{Ask, Bid, CollectionBid, Offset, SudoParams, TokenId};
-use cosmwasm_std::{to_binary, Addr, Binary, Coin, StdResult, Timestamp, WasmMsg};
+use crate::state::{Ask, Bid, CollectionBid, SudoParams, TokenId};
+use cosmwasm_std::{to_binary, Addr, Binary, Coin, StdResult, Timestamp, Uint128, WasmMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sg_std::CosmosMsg;
@@ -103,6 +103,19 @@ pub enum SudoMsg {
 pub type Collection = String;
 pub type Bidder = String;
 pub type Seller = String;
+
+/// Offsets for pagination
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Offset {
+    pub price: Uint128,
+    pub token_id: TokenId,
+}
+
+impl Offset {
+    pub fn new(price: Uint128, token_id: TokenId) -> Self {
+        Offset { price, token_id }
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -37,8 +37,10 @@ pub fn contract_sg721() -> Box<dyn Contract<StargazeMsgWrapper>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::msg::{AsksResponse, BidResponse, CollectionsResponse, ParamsResponse, SudoMsg};
-    use crate::state::{Bid, Offset};
+    use crate::msg::{
+        AsksResponse, BidResponse, CollectionsResponse, Offset, ParamsResponse, SudoMsg,
+    };
+    use crate::state::Bid;
 
     use super::*;
     use cosmwasm_std::{coin, coins, Coin, Decimal, Uint128};
@@ -698,13 +700,8 @@ mod tests {
         assert_eq!(res.asks[1].price.u128(), 110u128);
         assert_eq!(res.asks[2].price.u128(), 111u128);
 
-        let start_after = Offset::new(res.asks[0].price.u128(), res.asks[0].token_id);
-        println!(
-            "{:?}{:?}",
-            start_after.clone().price,
-            start_after.clone().token_id
-        );
-        let query_asks_start_after_first_msg = QueryMsg::AsksSortedByPrice {
+        let start_after = Offset::new(res.asks[0].price, res.asks[0].token_id);
+        let query_msg = QueryMsg::AsksSortedByPrice {
             collection: collection.to_string(),
             start_after: Some(start_after),
             limit: None,
@@ -712,7 +709,7 @@ mod tests {
 
         let res: AsksResponse = router
             .wrap()
-            .query_wasm_smart(marketplace.clone(), &query_asks_start_after_first_msg)
+            .query_wasm_smart(marketplace.clone(), &query_msg)
             .unwrap();
         assert_eq!(res.asks.len(), 2);
         assert_eq!(res.asks[0].price.u128(), 110u128);
@@ -733,7 +730,7 @@ mod tests {
         assert_eq!(res.asks[1].price.u128(), 110u128);
         assert_eq!(res.asks[2].price.u128(), 109u128);
 
-        let start_before = Offset::new(res.asks[0].price.u128(), res.asks[0].token_id);
+        let start_before = Offset::new(res.asks[0].price, res.asks[0].token_id);
         let reverse_query_asks_start_before_first_desc_msg = QueryMsg::ReverseAsksSortedByPrice {
             collection: collection.to_string(),
             start_before: Some(start_before),

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -1,10 +1,10 @@
 use crate::msg::{
     AskCountResponse, AsksResponse, BidResponse, Bidder, BidsResponse, Collection,
-    CollectionBidResponse, CollectionBidsResponse, CollectionsResponse, CurrentAskResponse,
+    CollectionBidResponse, CollectionBidsResponse, CollectionsResponse, CurrentAskResponse, Offset,
     ParamsResponse, QueryMsg,
 };
 use crate::state::{
-    ask_key, asks, bids, collection_bid_key, collection_bids, Offset, TokenId, ASK_HOOKS,
+    ask_key, asks, bids, collection_bid_key, collection_bids, TokenId, ASK_HOOKS,
     SALE_FINALIZED_HOOKS, SUDO_PARAMS,
 };
 use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Deps, Env, Order, StdResult};
@@ -169,14 +169,12 @@ pub fn query_asks_sorted_by_price(
 ) -> StdResult<AsksResponse> {
     let limit = limit.unwrap_or(DEFAULT_QUERY_LIMIT).min(MAX_QUERY_LIMIT) as usize;
 
-    let start = if let Some(offset) = start_after {
-        Some(Bound::exclusive((
-            offset.price,
+    let start = start_after.map(|offset| {
+        Bound::exclusive((
+            offset.price.u128(),
             ask_key(collection.clone(), offset.token_id),
-        )))
-    } else {
-        None
-    };
+        ))
+    });
 
     let asks = asks()
         .idx
@@ -198,14 +196,12 @@ pub fn reverse_query_asks_sorted_by_price(
 ) -> StdResult<AsksResponse> {
     let limit = limit.unwrap_or(DEFAULT_QUERY_LIMIT).min(MAX_QUERY_LIMIT) as usize;
 
-    let end = if let Some(offset) = start_before {
-        Some(Bound::exclusive((
-            offset.price,
+    let end = start_before.map(|offset| {
+        Bound::exclusive((
+            offset.price.u128(),
             ask_key(collection.clone(), offset.token_id),
-        )))
-    } else {
-        None
-    };
+        ))
+    });
 
     let asks = asks()
         .idx

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -46,18 +46,6 @@ pub type AskKey = (Addr, TokenId);
 pub fn ask_key(collection: Addr, token_id: TokenId) -> AskKey {
     (collection, token_id)
 }
-/// Offsets for pagination
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Offset {
-    pub price: u128,
-    pub token_id: TokenId,
-}
-
-impl Offset {
-    pub fn new(price: u128, token_id: TokenId) -> Self {
-        Offset { price, token_id }
-    }
-}
 
 /// Defines indices for accessing Asks
 pub struct AskIndicies<'a> {

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -1,3 +1,5 @@
+import { Uint128 } from "./shared-types";
+
 export type QueryMsg = ({
 current_ask: {
 collection: string
@@ -15,7 +17,14 @@ start_after?: (number | null)
 asks_sorted_by_price: {
 collection: string
 limit?: (number | null)
-order_asc: boolean
+start_after?: (Offset | null)
+[k: string]: unknown
+}
+} | {
+reverse_asks_sorted_by_price: {
+collection: string
+limit?: (number | null)
+start_before?: (Offset | null)
 [k: string]: unknown
 }
 } | {
@@ -92,3 +101,12 @@ ask_hooks: {
 [k: string]: unknown
 }
 })
+
+/**
+ * Offsets for pagination
+ */
+export interface Offset {
+price: Uint128
+token_id: number
+[k: string]: unknown
+}


### PR DESCRIPTION
This was because `u128` is too large of type to serialize as a number. It's beyond any numerical type that Javascript supports for example. For this reason there's a CosmWasm `Uint128` type that treats 128-bit integers as strings for transport. It's this type that should be used in anything that goes over the wire (like structs in query messages). 