### PR TITLE
add pagination query bids by price

### DIFF
--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -122,7 +122,7 @@
             "start_after": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/PriceOffset"
+                  "$ref": "#/definitions/AskOffset"
                 },
                 {
                   "type": "null"
@@ -161,7 +161,7 @@
             "start_before": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/PriceOffset"
+                  "$ref": "#/definitions/AskOffset"
                 },
                 {
                   "type": "null"
@@ -371,7 +371,7 @@
             "start_after": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/BidPriceOffset"
+                  "$ref": "#/definitions/BidOffset"
                 },
                 {
                   "type": "null"
@@ -507,8 +507,26 @@
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
     },
-    "BidPriceOffset": {
-      "description": "Offsets for bid price pagination",
+    "AskOffset": {
+      "description": "Offset for ask pagination",
+      "type": "object",
+      "required": [
+        "price",
+        "token_id"
+      ],
+      "properties": {
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "BidOffset": {
+      "description": "Offset for bid pagination",
       "type": "object",
       "required": [
         "bidder",
@@ -530,6 +548,7 @@
       }
     },
     "CollectionOffset": {
+      "description": "Offset for collection pagination",
       "type": "object",
       "required": [
         "collection",
@@ -538,24 +557,6 @@
       "properties": {
         "collection": {
           "type": "string"
-        },
-        "token_id": {
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
-        }
-      }
-    },
-    "PriceOffset": {
-      "description": "Offsets for pagination",
-      "type": "object",
-      "required": [
-        "price",
-        "token_id"
-      ],
-      "properties": {
-        "price": {
-          "$ref": "#/definitions/Uint128"
         },
         "token_id": {
           "type": "integer",

--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -354,8 +354,7 @@
         "bids_sorted_by_price": {
           "type": "object",
           "required": [
-            "collection",
-            "order_asc"
+            "collection"
           ],
           "properties": {
             "collection": {
@@ -369,8 +368,15 @@
               "format": "uint32",
               "minimum": 0.0
             },
-            "order_asc": {
-              "type": "boolean"
+            "start_after": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/BidPriceOffset"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         }
@@ -497,6 +503,32 @@
     }
   ],
   "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "BidPriceOffset": {
+      "description": "Offsets for bid price pagination",
+      "type": "object",
+      "required": [
+        "bidder",
+        "price",
+        "token_id"
+      ],
+      "properties": {
+        "bidder": {
+          "$ref": "#/definitions/Addr"
+        },
+        "price": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "token_id": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
     "CollectionOffset": {
       "type": "object",
       "required": [

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -208,7 +208,6 @@ pub enum QueryMsg {
     BidsSortedByPrice {
         collection: Collection,
         limit: Option<u32>,
-        order_asc: bool,
     },
     /// Get data for a specific collection bid
     /// Return type: `CollectionBidResponse`

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -107,37 +107,37 @@ pub type Collection = String;
 pub type Bidder = String;
 pub type Seller = String;
 
-/// Offsets for pagination
+/// Offset for ask pagination
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct PriceOffset {
+pub struct AskOffset {
     pub price: Uint128,
     pub token_id: TokenId,
 }
 
-impl PriceOffset {
+impl AskOffset {
     pub fn new(price: Uint128, token_id: TokenId) -> Self {
-        PriceOffset { price, token_id }
+        AskOffset { price, token_id }
     }
 }
 
-/// Offsets for bid price pagination
+/// Offset for bid pagination
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct BidPriceOffset {
+pub struct BidOffset {
     pub price: Uint128,
     pub token_id: TokenId,
     pub bidder: Addr,
 }
 
-impl BidPriceOffset {
+impl BidOffset {
     pub fn new(price: Uint128, token_id: TokenId, bidder: Addr) -> Self {
-        BidPriceOffset {
+        BidOffset {
             price,
             token_id,
             bidder,
         }
     }
 }
-
+/// Offset for collection pagination
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CollectionOffset {
     pub collection: String,
@@ -179,14 +179,14 @@ pub enum QueryMsg {
     /// Return type: `AsksResponse`
     AsksSortedByPrice {
         collection: Collection,
-        start_after: Option<PriceOffset>,
+        start_after: Option<AskOffset>,
         limit: Option<u32>,
     },
     /// Get all asks for a collection, sorted by price in reverse
     /// Return type: `AsksResponse`
     ReverseAsksSortedByPrice {
         collection: Collection,
-        start_before: Option<PriceOffset>,
+        start_before: Option<AskOffset>,
         limit: Option<u32>,
     },
     /// Count of all asks
@@ -225,7 +225,7 @@ pub enum QueryMsg {
     /// Return type: `BidsResponse`
     BidsSortedByPrice {
         collection: Collection,
-        start_after: Option<BidPriceOffset>,
+        start_after: Option<BidOffset>,
         limit: Option<u32>,
     },
     /// Get data for a specific collection bid

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -120,6 +120,24 @@ impl PriceOffset {
     }
 }
 
+/// Offsets for bid price pagination
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct BidPriceOffset {
+    pub price: Uint128,
+    pub token_id: TokenId,
+    pub bidder: Addr,
+}
+
+impl BidPriceOffset {
+    pub fn new(price: Uint128, token_id: TokenId, bidder: Addr) -> Self {
+        BidPriceOffset {
+            price,
+            token_id,
+            bidder,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CollectionOffset {
     pub collection: String,
@@ -207,6 +225,7 @@ pub enum QueryMsg {
     /// Return type: `BidsResponse`
     BidsSortedByPrice {
         collection: Collection,
+        start_after: Option<BidPriceOffset>,
         limit: Option<u32>,
     },
     /// Get data for a specific collection bid

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -39,8 +39,8 @@ pub fn contract_sg721() -> Box<dyn Contract<StargazeMsgWrapper>> {
 mod tests {
     use crate::helpers::ExpiryRange;
     use crate::msg::{
-        AskCountResponse, AsksResponse, BidPriceOffset, BidResponse, CollectionOffset,
-        CollectionsResponse, ParamsResponse, PriceOffset, SudoMsg,
+        AskCountResponse, AskOffset, AsksResponse, BidOffset, BidResponse, CollectionOffset,
+        CollectionsResponse, ParamsResponse, SudoMsg,
     };
     use crate::state::Bid;
 
@@ -621,7 +621,7 @@ mod tests {
         assert_eq!(res.asks[1].price.u128(), 110u128);
         assert_eq!(res.asks[2].price.u128(), 111u128);
 
-        let start_after = PriceOffset::new(res.asks[0].price, res.asks[0].token_id);
+        let start_after = AskOffset::new(res.asks[0].price, res.asks[0].token_id);
         let query_msg = QueryMsg::AsksSortedByPrice {
             collection: collection.to_string(),
             start_after: Some(start_after),
@@ -651,7 +651,7 @@ mod tests {
         assert_eq!(res.asks[1].price.u128(), 110u128);
         assert_eq!(res.asks[2].price.u128(), 109u128);
 
-        let start_before = PriceOffset::new(res.asks[0].price, res.asks[0].token_id);
+        let start_before = AskOffset::new(res.asks[0].price, res.asks[0].token_id);
         let reverse_query_asks_start_before_first_desc_msg = QueryMsg::ReverseAsksSortedByPrice {
             collection: collection.to_string(),
             start_before: Some(start_before),
@@ -983,7 +983,7 @@ mod tests {
         assert_eq!(res.bids[3].price.u128(), 7u128);
 
         // test start_after query
-        let start_after = BidPriceOffset {
+        let start_after = BidOffset {
             price: res.bids[2].price,
             token_id: res.bids[2].token_id,
             bidder: res.bids[2].bidder.clone(),

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -934,7 +934,6 @@ mod tests {
         let query_bids_msg = QueryMsg::BidsSortedByPrice {
             collection: collection.to_string(),
             limit: None,
-            order_asc: true,
         };
         let res: BidsResponse = router
             .wrap()

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -1,7 +1,7 @@
 use crate::msg::{
-    AskCountResponse, AskResponse, AsksResponse, BidPriceOffset, BidResponse, Bidder, BidsResponse,
-    Collection, CollectionBidResponse, CollectionBidsResponse, CollectionOffset,
-    CollectionsResponse, ParamsResponse, PriceOffset, QueryMsg,
+    AskCountResponse, AskOffset, AskResponse, AsksResponse, BidOffset, BidResponse, Bidder,
+    BidsResponse, Collection, CollectionBidResponse, CollectionBidsResponse, CollectionOffset,
+    CollectionsResponse, ParamsResponse, QueryMsg,
 };
 use crate::state::{
     ask_key, asks, bid_key, bids, collection_bid_key, collection_bids, BidKey, TokenId, ASK_HOOKS,
@@ -190,7 +190,7 @@ pub fn query_asks(
 pub fn query_asks_sorted_by_price(
     deps: Deps,
     collection: Addr,
-    start_after: Option<PriceOffset>,
+    start_after: Option<AskOffset>,
     limit: Option<u32>,
 ) -> StdResult<AsksResponse> {
     let limit = limit.unwrap_or(DEFAULT_QUERY_LIMIT).min(MAX_QUERY_LIMIT) as usize;
@@ -217,7 +217,7 @@ pub fn query_asks_sorted_by_price(
 pub fn reverse_query_asks_sorted_by_price(
     deps: Deps,
     collection: Addr,
-    start_before: Option<PriceOffset>,
+    start_before: Option<AskOffset>,
     limit: Option<u32>,
 ) -> StdResult<AsksResponse> {
     let limit = limit.unwrap_or(DEFAULT_QUERY_LIMIT).min(MAX_QUERY_LIMIT) as usize;
@@ -352,7 +352,7 @@ pub fn query_bids(
 pub fn query_bids_sorted_by_price(
     deps: Deps,
     collection: Addr,
-    start_after: Option<BidPriceOffset>,
+    start_after: Option<BidOffset>,
     limit: Option<u32>,
 ) -> StdResult<BidsResponse> {
     let limit = limit.unwrap_or(DEFAULT_QUERY_LIMIT).min(MAX_QUERY_LIMIT) as usize;

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -1,4 +1,4 @@
-import { Uint128 } from "./shared-types";
+import { Addr, Uint128 } from "./shared-types";
 
 export type QueryMsg = ({
 collections: {
@@ -23,14 +23,14 @@ start_after?: (number | null)
 asks_sorted_by_price: {
 collection: string
 limit?: (number | null)
-start_after?: (PriceOffset | null)
+start_after?: (AskOffset | null)
 [k: string]: unknown
 }
 } | {
 reverse_asks_sorted_by_price: {
 collection: string
 limit?: (number | null)
-start_before?: (PriceOffset | null)
+start_before?: (AskOffset | null)
 [k: string]: unknown
 }
 } | {
@@ -71,7 +71,7 @@ token_id: number
 bids_sorted_by_price: {
 collection: string
 limit?: (number | null)
-order_asc: boolean
+start_after?: (BidOffset | null)
 [k: string]: unknown
 }
 } | {
@@ -107,15 +107,27 @@ params: {
 })
 
 /**
- * Offsets for pagination
+ * Offset for ask pagination
  */
-export interface PriceOffset {
+export interface AskOffset {
 price: Uint128
 token_id: number
 [k: string]: unknown
 }
+/**
+ * Offset for collection pagination
+ */
 export interface CollectionOffset {
 collection: string
+token_id: number
+[k: string]: unknown
+}
+/**
+ * Offset for bid pagination
+ */
+export interface BidOffset {
+bidder: Addr
+price: Uint128
 token_id: number
 [k: string]: unknown
 }


### PR DESCRIPTION
fix #119 

`PriceOffset` won't work for bidders as is, since `bid_key` needs `(collection, token_id, bidder)` for pagination.
