### PR TITLE
Renamed hooks

### DIFF
--- a/contracts/marketplace/examples/schema.rs
+++ b/contracts/marketplace/examples/schema.rs
@@ -1,8 +1,8 @@
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 use sg_marketplace::msg::{
-    AskCountResponse, AskResponse, AsksResponse, BidResponse, BidsResponse, CollectionBidResponse,
-    CollectionsResponse, ExecuteMsg, InstantiateMsg, ParamsResponse, QueryMsg,
-    SaleFinalizedHookMsg, SudoMsg,
+    AskCountResponse, AskCreatedHookMsg, AskFilledHookMsg, AskResponse, AsksResponse, BidResponse,
+    BidsResponse, CollectionBidResponse, CollectionsResponse, ExecuteMsg, InstantiateMsg,
+    ParamsResponse, QueryMsg, SudoMsg,
 };
 use sg_marketplace::MarketplaceContract;
 use std::env::current_dir;
@@ -58,8 +58,13 @@ fn main() {
         "ListedCollectionsResponse",
     );
     export_schema_with_title(
-        &schema_for!(SaleFinalizedHookMsg),
+        &schema_for!(AskFilledHookMsg),
         &out_dir,
-        "SaleFinalizedHooksResponse",
+        "AskFilledHooksResponse",
+    );
+    export_schema_with_title(
+        &schema_for!(AskCreatedHookMsg),
+        &out_dir,
+        "AskCreatedHooksResponse",
     );
 }

--- a/contracts/marketplace/schema/ask_created_hooks_response.json
+++ b/contracts/marketplace/schema/ask_created_hooks_response.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AskCreatedHooksResponse",
+  "type": "object",
+  "required": [
+    "collection",
+    "funds_recipient",
+    "price",
+    "seller",
+    "token_id"
+  ],
+  "properties": {
+    "collection": {
+      "type": "string"
+    },
+    "funds_recipient": {
+      "type": "string"
+    },
+    "price": {
+      "$ref": "#/definitions/Coin"
+    },
+    "seller": {
+      "type": "string"
+    },
+    "token_id": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    }
+  },
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/marketplace/schema/ask_filled_hooks_response.json
+++ b/contracts/marketplace/schema/ask_filled_hooks_response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "SaleFinalizedHooksResponse",
+  "title": "AskFilledHooksResponse",
   "type": "object",
   "required": [
     "buyer",

--- a/contracts/marketplace/schema/instantiate_msg.json
+++ b/contracts/marketplace/schema/instantiate_msg.json
@@ -17,6 +17,12 @@
         }
       ]
     },
+    "ask_filled_hook": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "bid_expiry": {
       "description": "Valid time range for Bids (min, max) in seconds",
       "allOf": [
@@ -31,12 +37,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "sales_finalized_hook": {
-      "type": [
-        "string",
-        "null"
-      ]
     },
     "trading_fee_basis_points": {
       "description": "Fair Burn fee for winning bids 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250",

--- a/contracts/marketplace/schema/query_msg.json
+++ b/contracts/marketplace/schema/query_msg.json
@@ -466,10 +466,10 @@
       "description": "Show all registered ask hooks Return type: `HooksResponse`",
       "type": "object",
       "required": [
-        "ask_hooks"
+        "ask_created_hooks"
       ],
       "properties": {
-        "ask_hooks": {
+        "ask_created_hooks": {
           "type": "object"
         }
       },
@@ -479,10 +479,10 @@
       "description": "Show all registered sale finalized hooks Return type: `HooksResponse`",
       "type": "object",
       "required": [
-        "sale_finalized_hooks"
+        "ask_filled_hooks"
       ],
       "properties": {
-        "sale_finalized_hooks": {
+        "ask_filled_hooks": {
           "type": "object"
         }
       },

--- a/contracts/marketplace/schema/sudo_msg.json
+++ b/contracts/marketplace/schema/sudo_msg.json
@@ -55,55 +55,13 @@
       "additionalProperties": false
     },
     {
-      "description": "Add a new hook to be informed of all trades",
-      "type": "object",
-      "required": [
-        "add_sale_finalized_hook"
-      ],
-      "properties": {
-        "add_sale_finalized_hook": {
-          "type": "object",
-          "required": [
-            "hook"
-          ],
-          "properties": {
-            "hook": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    {
       "description": "Add a new hook to be informed of all asks",
       "type": "object",
       "required": [
-        "add_ask_hook"
+        "add_ask_created_hook"
       ],
       "properties": {
-        "add_ask_hook": {
-          "type": "object",
-          "required": [
-            "hook"
-          ],
-          "properties": {
-            "hook": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    {
-      "description": "Remove a trade hook",
-      "type": "object",
-      "required": [
-        "remove_sale_finalized_hook"
-      ],
-      "properties": {
-        "remove_sale_finalized_hook": {
+        "add_ask_created_hook": {
           "type": "object",
           "required": [
             "hook"
@@ -121,10 +79,52 @@
       "description": "Remove a ask hook",
       "type": "object",
       "required": [
-        "remove_ask_hook"
+        "remove_ask_created_hook"
       ],
       "properties": {
-        "remove_ask_hook": {
+        "remove_ask_created_hook": {
+          "type": "object",
+          "required": [
+            "hook"
+          ],
+          "properties": {
+            "hook": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Add a new hook to be informed of all trades",
+      "type": "object",
+      "required": [
+        "add_ask_filled_hook"
+      ],
+      "properties": {
+        "add_ask_filled_hook": {
+          "type": "object",
+          "required": [
+            "hook"
+          ],
+          "properties": {
+            "hook": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Remove a trade hook",
+      "type": "object",
+      "required": [
+        "remove_ask_filled_hook"
+      ],
+      "properties": {
+        "remove_ask_filled_hook": {
           "type": "object",
           "required": [
             "hook"

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -1,9 +1,9 @@
 use crate::error::ContractError;
 use crate::helpers::map_validate;
-use crate::msg::{AskHookMsg, ExecuteMsg, InstantiateMsg, SaleFinalizedHookMsg};
+use crate::msg::{AskCreatedHookMsg, AskFilledHookMsg, ExecuteMsg, InstantiateMsg};
 use crate::state::{
     ask_key, asks, bid_key, bids, collection_bid_key, collection_bids, Ask, Bid, CollectionBid,
-    SudoParams, TokenId, ASK_HOOKS, SALE_FINALIZED_HOOKS, SUDO_PARAMS,
+    SudoParams, TokenId, ASK_CREATED_HOOKS, ASK_FILLED_HOOKS, SUDO_PARAMS,
 };
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -23,8 +23,8 @@ use sg_std::{CosmosMsg, Response, SubMsg, NATIVE_DENOM};
 const CONTRACT_NAME: &str = "crates.io:sg-marketplace";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const REPLY_SALE_FINALIZED_HOOK: u64 = 1;
-const REPLY_ASK_HOOK: u64 = 2;
+const REPLY_ASK_FILLED_HOOK: u64 = 1;
+const REPLY_ASK_CREATED_HOOK: u64 = 2;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -45,9 +45,9 @@ pub fn instantiate(
 
     let mut res = Response::new().add_attribute("action", "instantiate");
 
-    if let Some(hook) = msg.sales_finalized_hook {
-        SALE_FINALIZED_HOOKS.add_hook(deps.storage, deps.api.addr_validate(&hook)?)?;
-        res = res.add_attribute("action", "add_sale_finalized_hook");
+    if let Some(hook) = msg.ask_filled_hook {
+        ASK_FILLED_HOOKS.add_hook(deps.storage, deps.api.addr_validate(&hook)?)?;
+        res = res.add_attribute("action", "add_ask_filled_hook");
         res = res.add_attribute("hook", hook);
     }
 
@@ -196,7 +196,7 @@ pub fn execute_set_ask(
         },
     )?;
 
-    let msg = AskHookMsg {
+    let msg = AskCreatedHookMsg {
         collection: collection.to_string(),
         token_id,
         seller: seller.to_string(),
@@ -205,13 +205,13 @@ pub fn execute_set_ask(
     };
 
     // Include hook submessages, i.e: listing rewards
-    let submsgs = ASK_HOOKS.prepare_hooks(deps.storage, |h| {
+    let submsgs = ASK_CREATED_HOOKS.prepare_hooks(deps.storage, |h| {
         let execute = WasmMsg::Execute {
             contract_addr: h.to_string(),
             msg: msg.clone().into_binary()?,
             funds: vec![],
         };
-        Ok(SubMsg::reply_on_error(execute, REPLY_ASK_HOOK))
+        Ok(SubMsg::reply_on_error(execute, REPLY_ASK_CREATED_HOOK))
     })?;
 
     let res = Response::new()
@@ -380,7 +380,7 @@ pub fn execute_set_bid(
         let owner = deps.api.addr_validate(&cw721_res.owner)?;
 
         // Include messages needed to finalize nft transfer and payout
-        let (msgs, submsgs) = finalize_sale(
+        let (msgs, submsgs) = fill_ask(
             deps,
             collection.clone(),
             token_id,
@@ -391,7 +391,7 @@ pub fn execute_set_bid(
         )?;
 
         res = res
-            .add_attribute("action", "sale_finalized")
+            .add_attribute("action", "ask_filled")
             .add_messages(msgs)
             .add_submessages(submsgs);
     }
@@ -480,7 +480,7 @@ pub fn execute_accept_bid(
     bids().remove(deps.storage, (collection.clone(), token_id, bidder.clone()))?;
 
     // Transfer funds and NFT
-    let (msgs, submsgs) = finalize_sale(
+    let (msgs, submsgs) = fill_ask(
         deps,
         collection.clone(),
         token_id,
@@ -576,7 +576,7 @@ pub fn execute_accept_collection_bid(
     )?;
 
     // Transfer funds and NFT
-    let (msgs, submsgs) = finalize_sale(
+    let (msgs, submsgs) = fill_ask(
         deps,
         collection.clone(),
         token_id,
@@ -613,7 +613,7 @@ fn only_owner(
 }
 
 /// Transfers funds and NFT, updates bid
-fn finalize_sale(
+fn fill_ask(
     deps: DepsMut,
     collection: Addr,
     token_id: u32,
@@ -644,7 +644,7 @@ fn finalize_sale(
 
     msgs.append(&mut vec![exec_cw721_transfer.into()]);
 
-    let msg = SaleFinalizedHookMsg {
+    let msg = AskFilledHookMsg {
         collection: collection.to_string(),
         token_id,
         price,
@@ -652,13 +652,13 @@ fn finalize_sale(
         buyer: recipient.to_string(),
     };
 
-    let submsg = SALE_FINALIZED_HOOKS.prepare_hooks(deps.storage, |h| {
+    let submsg = ASK_FILLED_HOOKS.prepare_hooks(deps.storage, |h| {
         let execute = WasmMsg::Execute {
             contract_addr: h.to_string(),
             msg: msg.clone().into_binary()?,
             funds: vec![],
         };
-        Ok(SubMsg::reply_on_error(execute, REPLY_SALE_FINALIZED_HOOK))
+        Ok(SubMsg::reply_on_error(execute, REPLY_ASK_FILLED_HOOK))
     })?;
 
     Ok((msgs, submsg))
@@ -667,15 +667,15 @@ fn finalize_sale(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
     match msg.id {
-        REPLY_SALE_FINALIZED_HOOK => {
+        REPLY_ASK_FILLED_HOOK => {
             let res = Response::new()
-                .add_attribute("action", "sale_finalized_hook_failed")
+                .add_attribute("action", "ask_filled_hook_failed")
                 .add_attribute("error", msg.result.unwrap_err());
             Ok(res)
         }
-        REPLY_ASK_HOOK => {
+        REPLY_ASK_CREATED_HOOK => {
             let res = Response::new()
-                .add_attribute("action", "ask_hook_failed")
+                .add_attribute("action", "ask_created_hook_failed")
                 .add_attribute("error", msg.result.unwrap_err());
             Ok(res)
         }

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -21,7 +21,7 @@ pub struct InstantiateMsg {
     /// Operators are entites that are responsible for maintaining the active state of Asks.
     /// They listen to NFT transfer events, and update the active state of Asks.
     pub operators: Vec<String>,
-    pub sales_finalized_hook: Option<String>,
+    pub ask_filled_hook: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -93,14 +93,14 @@ pub enum SudoMsg {
         bid_expiry: Option<ExpiryRange>,
         operators: Option<Vec<String>>,
     },
-    /// Add a new hook to be informed of all trades
-    AddSaleFinalizedHook { hook: String },
     /// Add a new hook to be informed of all asks
-    AddAskHook { hook: String },
-    /// Remove a trade hook
-    RemoveSaleFinalizedHook { hook: String },
+    AddAskCreatedHook { hook: String },
     /// Remove a ask hook
-    RemoveAskHook { hook: String },
+    RemoveAskCreatedHook { hook: String },
+    /// Add a new hook to be informed of all trades
+    AddAskFilledHook { hook: String },
+    /// Remove a trade hook
+    RemoveAskFilledHook { hook: String },
 }
 
 pub type Collection = String;
@@ -246,10 +246,10 @@ pub enum QueryMsg {
     },
     /// Show all registered ask hooks
     /// Return type: `HooksResponse`
-    AskHooks {},
+    AskCreatedHooks {},
     /// Show all registered sale finalized hooks
     /// Return type: `HooksResponse`
-    SaleFinalizedHooks {},
+    AskFilledHooks {},
     /// Get the config for the contract
     /// Return type: `ParamsResponse`
     Params {},
@@ -302,7 +302,7 @@ pub struct CollectionBidsResponse {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
-pub struct SaleFinalizedHookMsg {
+pub struct AskFilledHookMsg {
     pub collection: String,
     pub token_id: u32,
     pub price: Coin,
@@ -310,7 +310,7 @@ pub struct SaleFinalizedHookMsg {
     pub buyer: String,
 }
 
-impl SaleFinalizedHookMsg {
+impl AskFilledHookMsg {
     pub fn new(
         collection: String,
         token_id: u32,
@@ -318,7 +318,7 @@ impl SaleFinalizedHookMsg {
         seller: String,
         buyer: String,
     ) -> Self {
-        SaleFinalizedHookMsg {
+        AskFilledHookMsg {
             collection,
             token_id,
             price,
@@ -329,7 +329,7 @@ impl SaleFinalizedHookMsg {
 
     /// serializes the message
     pub fn into_binary(self) -> StdResult<Binary> {
-        let msg = SaleFinalizedExecuteMsg::SaleFinalizedHook(self);
+        let msg = AskFilledExecuteMsg::AskFilledHook(self);
         to_binary(&msg)
     }
 
@@ -348,13 +348,13 @@ impl SaleFinalizedHookMsg {
 // This is just a helper to properly serialize the above message
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
-pub enum SaleFinalizedExecuteMsg {
-    SaleFinalizedHook(SaleFinalizedHookMsg),
+pub enum AskFilledExecuteMsg {
+    AskFilledHook(AskFilledHookMsg),
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
-pub struct AskHookMsg {
+pub struct AskCreatedHookMsg {
     pub collection: String,
     pub token_id: u32,
     pub seller: String,
@@ -362,7 +362,7 @@ pub struct AskHookMsg {
     pub price: Coin,
 }
 
-impl AskHookMsg {
+impl AskCreatedHookMsg {
     pub fn new(
         collection: String,
         token_id: u32,
@@ -370,7 +370,7 @@ impl AskHookMsg {
         funds_recipient: String,
         price: Coin,
     ) -> Self {
-        AskHookMsg {
+        AskCreatedHookMsg {
             collection,
             token_id,
             seller,
@@ -381,7 +381,7 @@ impl AskHookMsg {
 
     /// serializes the message
     pub fn into_binary(self) -> StdResult<Binary> {
-        let msg = AskExecuteMsg::AskHook(self);
+        let msg = AskCreatedExecuteMsg::AskCreatedHook(self);
         to_binary(&msg)
     }
 
@@ -400,6 +400,6 @@ impl AskHookMsg {
 // This is just a helper to properly serialize the above message
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
-pub enum AskExecuteMsg {
-    AskHook(AskHookMsg),
+pub enum AskCreatedExecuteMsg {
+    AskCreatedHook(AskCreatedHookMsg),
 }

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -72,7 +72,7 @@ mod tests {
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
-            sales_finalized_hook: None,
+            ask_filled_hook: None,
         };
         let marketplace = router
             .instantiate_contract(
@@ -1140,7 +1140,7 @@ mod tests {
             .unwrap();
 
         // Bid is accepted, sale has been finalized
-        assert_eq!("sale_finalized", res.events[1].attributes[1].value);
+        assert_eq!("ask_filled", res.events[1].attributes[1].value);
 
         // Check money is transfered
         let creator_native_balances = router.wrap().query_all_balances(creator).unwrap();
@@ -1350,7 +1350,7 @@ mod tests {
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
-            sales_finalized_hook: None,
+            ask_filled_hook: None,
         };
         let marketplace = router
             .instantiate_contract(
@@ -1484,20 +1484,20 @@ mod tests {
         // Instantiate and configure contracts
         let (marketplace, _) = setup_contracts(&mut router, &creator).unwrap();
 
-        let add_hook_msg = SudoMsg::AddSaleFinalizedHook {
+        let add_hook_msg = SudoMsg::AddAskFilledHook {
             hook: "hook".to_string(),
         };
         let res = router.wasm_sudo(marketplace.clone(), &add_hook_msg);
         assert!(res.is_ok());
 
-        let query_hooks_msg = QueryMsg::SaleFinalizedHooks {};
+        let query_hooks_msg = QueryMsg::AskFilledHooks {};
         let res: HooksResponse = router
             .wrap()
             .query_wasm_smart(marketplace.clone(), &query_hooks_msg)
             .unwrap();
         assert_eq!(res.hooks, vec!["hook".to_string()]);
 
-        let remove_hook_msg = SudoMsg::RemoveSaleFinalizedHook {
+        let remove_hook_msg = SudoMsg::RemoveAskFilledHook {
             hook: "hook".to_string(),
         };
         let res = router.wasm_sudo(marketplace.clone(), &remove_hook_msg);
@@ -1522,20 +1522,20 @@ mod tests {
             trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
-            sales_finalized_hook: Some("hook".to_string()),
+            ask_filled_hook: Some("hook".to_string()),
         };
         let marketplace = router
             .instantiate_contract(marketplace_id, creator, &msg, &[], "Marketplace", None)
             .unwrap();
 
-        let query_hooks_msg = QueryMsg::SaleFinalizedHooks {};
+        let query_hooks_msg = QueryMsg::AskFilledHooks {};
         let res: HooksResponse = router
             .wrap()
             .query_wasm_smart(marketplace.clone(), &query_hooks_msg)
             .unwrap();
         assert_eq!(res.hooks, vec!["hook".to_string()]);
 
-        let remove_hook_msg = SudoMsg::RemoveSaleFinalizedHook {
+        let remove_hook_msg = SudoMsg::RemoveAskFilledHook {
             hook: "hook".to_string(),
         };
         let res = router.wasm_sudo(marketplace.clone(), &remove_hook_msg);
@@ -1557,13 +1557,13 @@ mod tests {
         let (marketplace, collection) = setup_contracts(&mut router, &creator).unwrap();
 
         // Add sales hook
-        let add_hook_msg = SudoMsg::AddSaleFinalizedHook {
+        let add_hook_msg = SudoMsg::AddAskFilledHook {
             hook: "hook".to_string(),
         };
         let _res = router.wasm_sudo(marketplace.clone(), &add_hook_msg);
 
         // Add listed hook
-        let add_ask_hook_msg = SudoMsg::AddAskHook {
+        let add_ask_hook_msg = SudoMsg::AddAskCreatedHook {
             hook: "listed_hook".to_string(),
         };
         let _res = router.wasm_sudo(marketplace.clone(), &add_ask_hook_msg);
@@ -1591,7 +1591,7 @@ mod tests {
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
         assert_eq!(
-            "ask_hook_failed",
+            "ask_created_hook_failed",
             res.unwrap().events[3].attributes[1].value
         );
         // Bidder makes bid that meets the ask criteria
@@ -1610,7 +1610,7 @@ mod tests {
         );
         assert!(res.is_ok());
         assert_eq!(
-            "sale_finalized_hook_failed",
+            "ask_filled_hook_failed",
             res.unwrap().events[7].attributes[1].value
         );
 
@@ -1634,20 +1634,20 @@ mod tests {
         // Instantiate and configure contracts
         let (marketplace, _) = setup_contracts(&mut router, &creator).unwrap();
 
-        let add_hook_msg = SudoMsg::AddAskHook {
+        let add_hook_msg = SudoMsg::AddAskCreatedHook {
             hook: "hook".to_string(),
         };
         let res = router.wasm_sudo(marketplace.clone(), &add_hook_msg);
         assert!(res.is_ok());
 
-        let query_hooks_msg = QueryMsg::AskHooks {};
+        let query_hooks_msg = QueryMsg::AskCreatedHooks {};
         let res: HooksResponse = router
             .wrap()
             .query_wasm_smart(marketplace.clone(), &query_hooks_msg)
             .unwrap();
         assert_eq!(res.hooks, vec!["hook".to_string()]);
 
-        let remove_hook_msg = SudoMsg::RemoveAskHook {
+        let remove_hook_msg = SudoMsg::RemoveAskCreatedHook {
             hook: "hook".to_string(),
         };
         let res = router.wasm_sudo(marketplace.clone(), &remove_hook_msg);

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -4,8 +4,8 @@ use crate::msg::{
     CollectionsResponse, ParamsResponse, QueryMsg,
 };
 use crate::state::{
-    ask_key, asks, bid_key, bids, collection_bid_key, collection_bids, BidKey, TokenId, ASK_HOOKS,
-    SALE_FINALIZED_HOOKS, SUDO_PARAMS,
+    ask_key, asks, bid_key, bids, collection_bid_key, collection_bids, BidKey, TokenId,
+    ASK_CREATED_HOOKS, ASK_FILLED_HOOKS, SUDO_PARAMS,
 };
 use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Deps, Env, Order, StdResult};
 use cw_storage_plus::{Bound, PrefixBound};
@@ -131,8 +131,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&bidder)?,
         )?),
-        QueryMsg::AskHooks {} => to_binary(&ASK_HOOKS.query_hooks(deps)?),
-        QueryMsg::SaleFinalizedHooks {} => to_binary(&SALE_FINALIZED_HOOKS.query_hooks(deps)?),
+        QueryMsg::AskCreatedHooks {} => to_binary(&ASK_CREATED_HOOKS.query_hooks(deps)?),
+        QueryMsg::AskFilledHooks {} => to_binary(&ASK_FILLED_HOOKS.query_hooks(deps)?),
         QueryMsg::Params {} => to_binary(&query_params(deps)?),
     }
 }

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -22,11 +22,10 @@ pub struct SudoParams {
     pub operators: Vec<Addr>,
 }
 
-pub const SUDO_PARAMS: Item<SudoParams> = Item::new("sudo_params");
+pub const SUDO_PARAMS: Item<SudoParams> = Item::new("sudo-params");
 
-pub const SALE_FINALIZED_HOOKS: Hooks = Hooks::new("sale-finalized-hooks");
-
-pub const ASK_HOOKS: Hooks = Hooks::new("ask-hooks");
+pub const ASK_CREATED_HOOKS: Hooks = Hooks::new("ask-created-hooks");
+pub const ASK_FILLED_HOOKS: Hooks = Hooks::new("ask-filled-hooks");
 
 pub type TokenId = u32;
 

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -1,7 +1,7 @@
 use crate::error::ContractError;
 use crate::helpers::{map_validate, ExpiryRange};
 use crate::msg::SudoMsg;
-use crate::state::{ASK_HOOKS, SALE_FINALIZED_HOOKS, SUDO_PARAMS};
+use crate::state::{ASK_CREATED_HOOKS, ASK_FILLED_HOOKS, SUDO_PARAMS};
 use cosmwasm_std::{entry_point, Addr, Decimal, DepsMut, Env};
 use sg_std::Response;
 
@@ -23,14 +23,18 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractE
             bid_expiry,
             operators,
         ),
-        SudoMsg::AddSaleFinalizedHook { hook } => {
+        SudoMsg::AddAskFilledHook { hook } => {
             sudo_add_sale_finalized_hook(deps, api.addr_validate(&hook)?)
         }
-        SudoMsg::AddAskHook { hook } => sudo_add_ask_hook(deps, env, api.addr_validate(&hook)?),
-        SudoMsg::RemoveSaleFinalizedHook { hook } => {
+        SudoMsg::AddAskCreatedHook { hook } => {
+            sudo_add_ask_hook(deps, env, api.addr_validate(&hook)?)
+        }
+        SudoMsg::RemoveAskFilledHook { hook } => {
             sudo_remove_sale_finalized_hook(deps, api.addr_validate(&hook)?)
         }
-        SudoMsg::RemoveAskHook { hook } => sudo_remove_ask_hook(deps, api.addr_validate(&hook)?),
+        SudoMsg::RemoveAskCreatedHook { hook } => {
+            sudo_remove_ask_hook(deps, api.addr_validate(&hook)?)
+        }
     }
 }
 
@@ -59,19 +63,19 @@ pub fn sudo_update_params(
 }
 
 pub fn sudo_add_sale_finalized_hook(deps: DepsMut, hook: Addr) -> Result<Response, ContractError> {
-    SALE_FINALIZED_HOOKS.add_hook(deps.storage, hook.clone())?;
+    ASK_FILLED_HOOKS.add_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
-        .add_attribute("action", "add_sale_finalized_hook")
+        .add_attribute("action", "add_ask_filled_hook")
         .add_attribute("hook", hook);
     Ok(res)
 }
 
 pub fn sudo_add_ask_hook(deps: DepsMut, _env: Env, hook: Addr) -> Result<Response, ContractError> {
-    ASK_HOOKS.add_hook(deps.storage, hook.clone())?;
+    ASK_CREATED_HOOKS.add_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
-        .add_attribute("action", "add_ask_hook")
+        .add_attribute("action", "add_ask_created_hook")
         .add_attribute("hook", hook);
     Ok(res)
 }
@@ -80,19 +84,19 @@ pub fn sudo_remove_sale_finalized_hook(
     deps: DepsMut,
     hook: Addr,
 ) -> Result<Response, ContractError> {
-    SALE_FINALIZED_HOOKS.remove_hook(deps.storage, hook.clone())?;
+    ASK_FILLED_HOOKS.remove_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
-        .add_attribute("action", "remove_sale_finalized_hook")
+        .add_attribute("action", "remove_ask_filled_hook")
         .add_attribute("hook", hook);
     Ok(res)
 }
 
 pub fn sudo_remove_ask_hook(deps: DepsMut, hook: Addr) -> Result<Response, ContractError> {
-    ASK_HOOKS.remove_hook(deps.storage, hook.clone())?;
+    ASK_CREATED_HOOKS.remove_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
-        .add_attribute("action", "remove_ask_hook")
+        .add_attribute("action", "remove_ask_created_hook")
         .add_attribute("hook", hook);
     Ok(res)
 }

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -107,7 +107,7 @@ fn setup_contract(deps: DepsMut) {
         trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
         ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
-        sales_finalized_hook: None,
+        ask_filled_hook: None,
     };
     let info = mock_info(CREATOR, &[]);
     let res = instantiate(deps, mock_env(), info, msg).unwrap();
@@ -123,7 +123,7 @@ fn proper_initialization() {
         trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
         ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
-        sales_finalized_hook: None,
+        ask_filled_hook: None,
     };
     let info = mock_info("creator", &coins(1000, NATIVE_DENOM));
 

--- a/types/contracts/marketplace/ask_created_hooks_response.d.ts
+++ b/types/contracts/marketplace/ask_created_hooks_response.d.ts
@@ -1,0 +1,10 @@
+import { Coin } from "./shared-types";
+
+export interface AskCreatedHooksResponse {
+collection: string
+funds_recipient: string
+price: Coin
+seller: string
+token_id: number
+[k: string]: unknown
+}

--- a/types/contracts/marketplace/ask_filled_hooks_response.d.ts
+++ b/types/contracts/marketplace/ask_filled_hooks_response.d.ts
@@ -1,0 +1,10 @@
+import { Coin } from "./shared-types";
+
+export interface AskFilledHooksResponse {
+buyer: string
+collection: string
+price: Coin
+seller: string
+token_id: number
+[k: string]: unknown
+}

--- a/types/contracts/marketplace/index.ts
+++ b/types/contracts/marketplace/index.ts
@@ -1,4 +1,6 @@
 export * from "./ask_count_response";
+export * from "./ask_created_hooks_response";
+export * from "./ask_filled_hooks_response";
 export * from "./ask_response";
 // dedup emptied this file
 // export * from "./ask";

--- a/types/contracts/marketplace/instantiate_msg.d.ts
+++ b/types/contracts/marketplace/instantiate_msg.d.ts
@@ -5,6 +5,7 @@ export interface InstantiateMsg {
  * Valid time range for Asks (min, max) in seconds
  */
 ask_expiry: ExpiryRange
+ask_filled_hook?: (string | null)
 /**
  * Valid time range for Bids (min, max) in seconds
  */
@@ -13,7 +14,6 @@ bid_expiry: ExpiryRange
  * Operators are entites that are responsible for maintaining the active state of Asks. They listen to NFT transfer events, and update the active state of Asks.
  */
 operators: string[]
-sales_finalized_hook?: (string | null)
 /**
  * Fair Burn fee for winning bids 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250
  */

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -93,11 +93,11 @@ order_asc: boolean
 [k: string]: unknown
 }
 } | {
-ask_hooks: {
+ask_created_hooks: {
 [k: string]: unknown
 }
 } | {
-sale_finalized_hooks: {
+ask_filled_hooks: {
 [k: string]: unknown
 }
 } | {

--- a/types/contracts/marketplace/shared-types.d.ts
+++ b/types/contracts/marketplace/shared-types.d.ts
@@ -1,4 +1,23 @@
 /**
+ * A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u128` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);
+ *
+ * let b = Uint128::from(42u64); assert_eq!(b.u128(), 42);
+ *
+ * let c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```
+ */
+export type Uint128 = string;
+export interface Coin {
+    [k: string]: unknown;
+    amount: Uint128;
+    denom: string;
+}
+/**
  * A human readable address.
  *
  * In Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.
@@ -33,20 +52,6 @@ export type Timestamp = Uint64;
  */
 export type Uint64 = string;
 /**
- * A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.
- *
- * # Examples
- *
- * Use `from` to create instances of this and `u128` to get the value out:
- *
- * ``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);
- *
- * let b = Uint128::from(42u64); assert_eq!(b.u128(), 42);
- *
- * let c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```
- */
-export type Uint128 = string;
-/**
  * Represents an ask on the marketplace
  */
 export interface Ask {
@@ -69,11 +74,6 @@ export interface Bid {
     expires: Timestamp;
     price: Uint128;
     token_id: number;
-}
-export interface Coin {
-    [k: string]: unknown;
-    amount: Uint128;
-    denom: string;
 }
 export interface ExpiryRange {
     [k: string]: unknown;

--- a/types/contracts/marketplace/sudo_msg.d.ts
+++ b/types/contracts/marketplace/sudo_msg.d.ts
@@ -9,22 +9,22 @@ trading_fee_basis_points?: (number | null)
 [k: string]: unknown
 }
 } | {
-add_sale_finalized_hook: {
+add_ask_created_hook: {
 hook: string
 [k: string]: unknown
 }
 } | {
-add_ask_hook: {
+remove_ask_created_hook: {
 hook: string
 [k: string]: unknown
 }
 } | {
-remove_sale_finalized_hook: {
+add_ask_filled_hook: {
 hook: string
 [k: string]: unknown
 }
 } | {
-remove_ask_hook: {
+remove_ask_filled_hook: {
 hook: string
 [k: string]: unknown
 }


### PR DESCRIPTION
This is an attempt in more consistent naming. Going to do something similar for events. For example, `ask_created` and `ask_filled` for both the hooks and events.