### PR TITLE
Add a finder's fee when an ask is filled

### DIFF
--- a/contracts/marketplace/schema/ask_response.json
+++ b/contracts/marketplace/schema/ask_response.json
@@ -37,6 +37,14 @@
         "expires": {
           "$ref": "#/definitions/Timestamp"
         },
+        "finders_fee_bps": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "funds_recipient": {
           "anyOf": [
             {

--- a/contracts/marketplace/schema/asks_by_seller_response.json
+++ b/contracts/marketplace/schema/asks_by_seller_response.json
@@ -36,6 +36,14 @@
         "expires": {
           "$ref": "#/definitions/Timestamp"
         },
+        "finders_fee_bps": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "funds_recipient": {
           "anyOf": [
             {

--- a/contracts/marketplace/schema/asks_response.json
+++ b/contracts/marketplace/schema/asks_response.json
@@ -36,6 +36,14 @@
         "expires": {
           "$ref": "#/definitions/Timestamp"
         },
+        "finders_fee_bps": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "funds_recipient": {
           "anyOf": [
             {

--- a/contracts/marketplace/schema/asks_sorted_by_price_response.json
+++ b/contracts/marketplace/schema/asks_sorted_by_price_response.json
@@ -36,6 +36,14 @@
         "expires": {
           "$ref": "#/definitions/Timestamp"
         },
+        "finders_fee_bps": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "funds_recipient": {
           "anyOf": [
             {

--- a/contracts/marketplace/schema/execute_msg.json
+++ b/contracts/marketplace/schema/execute_msg.json
@@ -24,6 +24,14 @@
             "expires": {
               "$ref": "#/definitions/Timestamp"
             },
+            "finders_fee_basis_points": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "funds_recipient": {
               "type": [
                 "string",
@@ -159,6 +167,12 @@
             "expires": {
               "$ref": "#/definitions/Timestamp"
             },
+            "finder": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "token_id": {
               "type": "integer",
               "format": "uint32",
@@ -217,6 +231,12 @@
             "collection": {
               "type": "string"
             },
+            "finder": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "token_id": {
               "type": "integer",
               "format": "uint32",
@@ -272,6 +292,12 @@
             },
             "collection": {
               "type": "string"
+            },
+            "finder": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "token_id": {
               "type": "integer",

--- a/contracts/marketplace/schema/instantiate_msg.json
+++ b/contracts/marketplace/schema/instantiate_msg.json
@@ -5,8 +5,9 @@
   "required": [
     "ask_expiry",
     "bid_expiry",
+    "max_finders_fee_bps",
     "operators",
-    "trading_fee_basis_points"
+    "trading_fee_bps"
   ],
   "properties": {
     "ask_expiry": {
@@ -31,6 +32,12 @@
         }
       ]
     },
+    "max_finders_fee_bps": {
+      "description": "Max basis points for the finders fee",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "operators": {
       "description": "Operators are entites that are responsible for maintaining the active state of Asks. They listen to NFT transfer events, and update the active state of Asks.",
       "type": "array",
@@ -38,7 +45,7 @@
         "type": "string"
       }
     },
-    "trading_fee_basis_points": {
+    "trading_fee_bps": {
       "description": "Fair Burn fee for winning bids 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250",
       "type": "integer",
       "format": "uint64",

--- a/contracts/marketplace/schema/params_response.json
+++ b/contracts/marketplace/schema/params_response.json
@@ -43,8 +43,9 @@
       "required": [
         "ask_expiry",
         "bid_expiry",
+        "max_finders_fee_bps",
         "operators",
-        "trading_fee_basis_points"
+        "trading_fee_bps"
       ],
       "properties": {
         "ask_expiry": {
@@ -63,6 +64,14 @@
             }
           ]
         },
+        "max_finders_fee_bps": {
+          "description": "Max value for the finders fee",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Decimal"
+            }
+          ]
+        },
         "operators": {
           "description": "Operators are entites that are responsible for maintaining the active state of Asks They listen to NFT transfer events, and update the active state of Asks",
           "type": "array",
@@ -70,7 +79,7 @@
             "$ref": "#/definitions/Addr"
           }
         },
-        "trading_fee_basis_points": {
+        "trading_fee_bps": {
           "description": "Fair Burn fee for winning bids 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250",
           "allOf": [
             {

--- a/contracts/marketplace/schema/sudo_msg.json
+++ b/contracts/marketplace/schema/sudo_msg.json
@@ -32,6 +32,14 @@
                 }
               ]
             },
+            "max_finders_fee_bps": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "operators": {
               "type": [
                 "array",
@@ -41,7 +49,7 @@
                 "type": "string"
               }
             },
-            "trading_fee_basis_points": {
+            "trading_fee_bps": {
               "type": [
                 "integer",
                 "null"

--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -49,6 +49,9 @@ pub enum ContractError {
     #[error("Unrecognised reply id: {0}")]
     UnrecognisedReply(u64),
 
+    #[error("Invalid finders fee bps: {0}")]
+    InvalidFindersFeeBps(u64),
+
     #[error("{0}")]
     BidPaymentError(#[from] PaymentError),
 

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -73,6 +73,7 @@ pub fn execute(
             price,
             funds_recipient,
             reserve_for,
+            finders_fee_basis_points,
             expires,
         } => execute_set_ask(
             ExecuteEnv { deps, env, info },
@@ -81,6 +82,7 @@ pub fn execute(
             price,
             maybe_addr(api, funds_recipient)?,
             maybe_addr(api, reserve_for)?,
+            finders_fee_basis_points,
             expires,
         ),
         ExecuteMsg::RemoveAsk {
@@ -158,6 +160,7 @@ pub fn execute_set_ask(
     price: Coin,
     funds_recipient: Option<Addr>,
     reserve_for: Option<Addr>,
+    finders_fee_basis_points: Option<u64>,
     expires: Timestamp,
 ) -> Result<Response, ContractError> {
     let ExecuteEnv { deps, info, env } = env;
@@ -191,6 +194,7 @@ pub fn execute_set_ask(
             price: price.amount,
             funds_recipient: funds_recipient.clone(),
             reserve_for,
+            finders_fee_basis_points,
             expires,
             is_active: true,
         },
@@ -562,6 +566,7 @@ pub fn execute_accept_collection_bid(
         seller: info.sender.clone(),
         funds_recipient: None,
         reserve_for: None,
+        finders_fee_basis_points: None,
     };
 
     // Transfer funds and NFT

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -200,7 +200,7 @@ pub fn execute_set_ask(
             price: price.amount,
             funds_recipient: funds_recipient.clone(),
             reserve_for,
-            finders_fee_basis_points,
+            finders_fee_bps: finders_fee_basis_points,
             expires,
             is_active: true,
         },
@@ -575,7 +575,7 @@ pub fn execute_accept_collection_bid(
         seller: info.sender.clone(),
         funds_recipient: None,
         reserve_for: None,
-        finders_fee_basis_points: None,
+        finders_fee_bps: None,
     };
 
     // Transfer funds and NFT
@@ -624,7 +624,7 @@ fn fill_ask(
             .clone()
             .unwrap_or_else(|| ask.seller.clone()),
         finder,
-        ask.finders_fee_basis_points,
+        ask.finders_fee_bps,
         res,
     )?;
 

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -36,7 +36,7 @@ pub fn instantiate(
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     let params = SudoParams {
-        trading_fee_basis_points: Decimal::percent(msg.trading_fee_basis_points),
+        trading_fee_bps: Decimal::percent(msg.trading_fee_bps),
         ask_expiry: msg.ask_expiry,
         bid_expiry: msg.bid_expiry,
         operators: map_validate(deps.api, &msg.operators)?,
@@ -699,7 +699,7 @@ fn payout(
     let config = SUDO_PARAMS.load(deps.storage)?;
 
     // Append Fair Burn message
-    let network_fee = payment * config.trading_fee_basis_points / Uint128::from(100u128);
+    let network_fee = payment * config.trading_fee_bps / Uint128::from(100u128);
     fair_burn(network_fee.u128(), None, res);
 
     // Check if token supports royalties

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -22,6 +22,8 @@ pub struct InstantiateMsg {
     /// They listen to NFT transfer events, and update the active state of Asks.
     pub operators: Vec<String>,
     pub ask_filled_hook: Option<String>,
+    /// Max basis points for the finders fee
+    pub max_finders_fee_bps: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -93,10 +95,11 @@ pub enum SudoMsg {
     /// Update the contract parameters
     /// Can only be called by governance
     UpdateParams {
-        trading_fee_basis_points: Option<u64>,
+        trading_fee_bps: Option<u64>,
         ask_expiry: Option<ExpiryRange>,
         bid_expiry: Option<ExpiryRange>,
         operators: Option<Vec<String>>,
+        max_finders_fee_bps: Option<u64>,
     },
     /// Add a new hook to be informed of all asks
     AddAskCreatedHook { hook: String },

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -59,6 +59,7 @@ pub enum ExecuteMsg {
         collection: String,
         token_id: TokenId,
         expires: Timestamp,
+        finder: Option<String>,
     },
     /// Remove an existing bid from an ask
     RemoveBid {
@@ -70,6 +71,7 @@ pub enum ExecuteMsg {
         collection: String,
         token_id: TokenId,
         bidder: String,
+        finder: Option<String>,
     },
     /// Place a bid (limit order) across an entire collection
     SetCollectionBid {
@@ -81,6 +83,7 @@ pub enum ExecuteMsg {
         collection: String,
         token_id: TokenId,
         bidder: String,
+        finder: Option<String>,
     },
 }
 

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -11,7 +11,7 @@ use sg_std::CosmosMsg;
 pub struct InstantiateMsg {
     /// Fair Burn fee for winning bids
     /// 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250
-    pub trading_fee_basis_points: u64,
+    pub trading_fee_bps: u64,
     /// Valid time range for Asks
     /// (min, max) in seconds
     pub ask_expiry: ExpiryRange,

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -34,6 +34,7 @@ pub enum ExecuteMsg {
         price: Coin,
         funds_recipient: Option<String>,
         reserve_for: Option<String>,
+        finders_fee_basis_points: Option<u64>,
         expires: Timestamp,
     },
     /// Remove an existing ask from the marketplace

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -56,9 +56,10 @@ mod tests {
     const INITIAL_BALANCE: u128 = 2000;
 
     // Governance parameters
-    const TRADING_FEE_BASIS_POINTS: u64 = 200; // 2%
+    const TRADING_FEE_BPS: u64 = 200; // 2%
     const MIN_EXPIRY: u64 = 24 * 60 * 60; // 24 hours (in seconds)
     const MAX_EXPIRY: u64 = 180 * 24 * 60 * 60; // 6 months (in seconds)
+    const MAX_FINDERS_FEE_BPS: u64 = 1000; // 10%
 
     // Instantiates all needed contracts for testing
     fn setup_contracts(
@@ -69,10 +70,11 @@ mod tests {
         let marketplace_id = router.store_code(contract_marketplace());
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
-            trading_fee_bps: TRADING_FEE_BASIS_POINTS,
+            trading_fee_bps: TRADING_FEE_BPS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             ask_filled_hook: None,
+            max_finders_fee_bps: MAX_FINDERS_FEE_BPS,
         };
         let marketplace = router
             .instantiate_contract(
@@ -1582,10 +1584,11 @@ mod tests {
         let marketplace_id = router.store_code(contract_marketplace());
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
-            trading_fee_bps: TRADING_FEE_BASIS_POINTS,
+            trading_fee_bps: TRADING_FEE_BPS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             ask_filled_hook: None,
+            max_finders_fee_bps: MAX_FINDERS_FEE_BPS,
         };
         let marketplace = router
             .instantiate_contract(
@@ -1696,10 +1699,11 @@ mod tests {
         let (marketplace, _) = setup_contracts(&mut router, &creator).unwrap();
 
         let update_config_msg = SudoMsg::UpdateParams {
-            trading_fee_basis_points: Some(5),
+            trading_fee_bps: Some(5),
             ask_expiry: Some(ExpiryRange::new(1, 2)),
             bid_expiry: None,
             operators: Some(vec!["operator".to_string()]),
+            max_finders_fee_bps: None,
         };
         let res = router.wasm_sudo(marketplace.clone(), &update_config_msg);
         assert!(res.is_ok());
@@ -1757,10 +1761,11 @@ mod tests {
         let marketplace_id = router.store_code(contract_marketplace());
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
-            trading_fee_bps: TRADING_FEE_BASIS_POINTS,
+            trading_fee_bps: TRADING_FEE_BPS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             ask_filled_hook: Some("hook".to_string()),
+            max_finders_fee_bps: MAX_FINDERS_FEE_BPS,
         };
         let marketplace = router
             .instantiate_contract(marketplace_id, creator, &msg, &[], "Marketplace", None)

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -261,6 +261,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY - 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_err());
@@ -273,6 +274,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -315,6 +317,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -340,6 +343,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             bidder: bidder.to_string(),
+            finder: None,
         };
         let res =
             router.execute_contract(creator.clone(), marketplace.clone(), &accept_bid_msg, &[]);
@@ -393,6 +397,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -402,6 +407,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder,
@@ -456,6 +462,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -521,6 +528,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -609,6 +617,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -620,6 +629,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -631,6 +641,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -758,6 +769,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(owner.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -770,6 +782,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(owner2.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -782,6 +795,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(owner2.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -899,6 +913,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -910,6 +925,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -921,6 +937,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -930,6 +947,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -943,6 +961,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID + 1,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -956,6 +975,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID + 2,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder,
@@ -997,6 +1017,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder2,
@@ -1089,6 +1110,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -1111,6 +1133,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -1160,6 +1183,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_err());
@@ -1185,6 +1209,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         router
             .execute_contract(
@@ -1200,6 +1225,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router
             .execute_contract(
@@ -1260,6 +1286,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: Some(bidder.to_string()),
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -1269,6 +1296,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let err = router
             .execute_contract(
@@ -1288,6 +1316,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -1331,6 +1360,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -1340,6 +1370,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
 
         let res = router.execute_contract(
@@ -1399,6 +1430,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -1408,6 +1440,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -1436,6 +1469,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -1547,6 +1581,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         let res = router.execute_contract(creator.clone(), marketplace.clone(), &set_ask, &[]);
         assert!(res.is_ok());
@@ -1556,6 +1591,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
         let res = router.execute_contract(
             bidder.clone(),
@@ -1724,6 +1760,7 @@ mod tests {
             funds_recipient: None,
             reserve_for: None,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finders_fee_basis_points: Some(0),
         };
         // Creator Authorizes NFT
         let approve_msg = Cw721ExecuteMsg::<Empty>::Approve {
@@ -1745,6 +1782,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+            finder: None,
         };
 
         // Bid succeeds even though the hook contract cannot be found
@@ -1937,6 +1975,7 @@ mod tests {
             collection: collection.to_string(),
             token_id: TOKEN_ID,
             bidder: bidder.to_string(),
+            finder: None,
         };
         let res =
             router.execute_contract(creator.clone(), marketplace, &accept_collection_bid, &[]);

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -69,7 +69,7 @@ mod tests {
         let marketplace_id = router.store_code(contract_marketplace());
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
-            trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
+            trading_fee_bps: TRADING_FEE_BASIS_POINTS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             ask_filled_hook: None,
@@ -1582,7 +1582,7 @@ mod tests {
         let marketplace_id = router.store_code(contract_marketplace());
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
-            trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
+            trading_fee_bps: TRADING_FEE_BASIS_POINTS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             ask_filled_hook: None,
@@ -1709,7 +1709,7 @@ mod tests {
             .wrap()
             .query_wasm_smart(marketplace, &query_params_msg)
             .unwrap();
-        assert_eq!(res.params.trading_fee_basis_points, Decimal::percent(5));
+        assert_eq!(res.params.trading_fee_bps, Decimal::percent(5));
         assert_eq!(res.params.ask_expiry, ExpiryRange::new(1, 2));
         assert_eq!(res.params.operators, vec!["operator".to_string()]);
     }
@@ -1757,7 +1757,7 @@ mod tests {
         let marketplace_id = router.store_code(contract_marketplace());
         let msg = crate::msg::InstantiateMsg {
             operators: vec!["operator".to_string()],
-            trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
+            trading_fee_bps: TRADING_FEE_BASIS_POINTS,
             ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
             ask_filled_hook: Some("hook".to_string()),

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -38,7 +38,7 @@ pub struct Ask {
     pub price: Uint128,
     pub funds_recipient: Option<Addr>,
     pub reserve_for: Option<Addr>,
-    pub finders_fee_basis_points: Option<u64>,
+    pub finders_fee_bps: Option<u64>,
     pub expires: Timestamp,
     pub is_active: bool,
 }

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -20,6 +20,8 @@ pub struct SudoParams {
     /// Operators are entites that are responsible for maintaining the active state of Asks
     /// They listen to NFT transfer events, and update the active state of Asks
     pub operators: Vec<Addr>,
+    /// Max value for the finders fee
+    pub max_finders_fee_bps: Decimal,
 }
 
 pub const SUDO_PARAMS: Item<SudoParams> = Item::new("sudo-params");

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -10,7 +10,7 @@ use crate::helpers::ExpiryRange;
 pub struct SudoParams {
     /// Fair Burn fee for winning bids
     /// 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250
-    pub trading_fee_basis_points: Decimal,
+    pub trading_fee_bps: Decimal,
     /// Valid time range for Asks
     /// (min, max) in seconds
     pub ask_expiry: ExpiryRange,

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -38,6 +38,7 @@ pub struct Ask {
     pub price: Uint128,
     pub funds_recipient: Option<Addr>,
     pub reserve_for: Option<Addr>,
+    pub finders_fee_basis_points: Option<u64>,
     pub expires: Timestamp,
     pub is_active: bool,
 }

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -49,9 +49,9 @@ pub fn sudo_update_params(
 ) -> Result<Response, ContractError> {
     let mut params = SUDO_PARAMS.load(deps.storage)?;
 
-    params.trading_fee_basis_points = trading_fee
+    params.trading_fee_bps = trading_fee
         .map(Decimal::percent)
-        .unwrap_or(params.trading_fee_basis_points);
+        .unwrap_or(params.trading_fee_bps);
     params.ask_expiry = ask_expiry.unwrap_or(params.ask_expiry);
     params.bid_expiry = bid_expiry.unwrap_or(params.bid_expiry);
     if let Some(operators) = operators {

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -44,15 +44,15 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractE
 pub fn sudo_update_params(
     deps: DepsMut,
     _env: Env,
-    trading_fee: Option<u64>,
+    trading_fee_bps: Option<u64>,
     ask_expiry: Option<ExpiryRange>,
     bid_expiry: Option<ExpiryRange>,
     operators: Option<Vec<String>>,
-    max_finders_fee: Option<u64>,
+    max_finders_fee_bps: Option<u64>,
 ) -> Result<Response, ContractError> {
     let mut params = SUDO_PARAMS.load(deps.storage)?;
 
-    params.trading_fee_bps = trading_fee
+    params.trading_fee_bps = trading_fee_bps
         .map(Decimal::percent)
         .unwrap_or(params.trading_fee_bps);
     params.ask_expiry = ask_expiry.unwrap_or(params.ask_expiry);
@@ -60,7 +60,7 @@ pub fn sudo_update_params(
     if let Some(operators) = operators {
         params.operators = map_validate(deps.api, &operators)?;
     }
-    params.max_finders_fee_bps = max_finders_fee
+    params.max_finders_fee_bps = max_finders_fee_bps
         .map(Decimal::percent)
         .unwrap_or(params.max_finders_fee_bps);
     SUDO_PARAMS.save(deps.storage, &params)?;

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -36,6 +36,7 @@ fn ask_indexed_map() {
         reserve_for: None,
         expires: Timestamp::from_seconds(0),
         is_active: true,
+        finders_fee_basis_points: Some(0),
     };
     let key = ask_key(collection.clone(), TOKEN_ID);
     let res = asks().save(deps.as_mut().storage, key.clone(), &ask);
@@ -50,6 +51,7 @@ fn ask_indexed_map() {
         reserve_for: None,
         expires: Timestamp::from_seconds(0),
         is_active: true,
+        finders_fee_basis_points: Some(0),
     };
     let key2 = ask_key(collection.clone(), TOKEN_ID + 1);
     let res = asks().save(deps.as_mut().storage, key2, &ask2);
@@ -146,6 +148,7 @@ fn try_set_bid() {
         collection: COLLECTION.to_string(),
         token_id: TOKEN_ID,
         expires: Timestamp::from_seconds(0),
+        finder: None,
     };
 
     // Broke bidder calls Set Bid and gets an error
@@ -159,6 +162,7 @@ fn try_set_bid() {
         collection: COLLECTION.to_string(),
         token_id: TOKEN_ID,
         expires: mock_env().block.time.plus_seconds(MIN_EXPIRY + 1),
+        finder: None,
     };
 
     // Bidder calls SetBid before an Ask is set, so it should fail
@@ -185,6 +189,7 @@ fn try_set_ask() {
         expires: Timestamp::from_seconds(
             mock_env().block.time.plus_seconds(MIN_EXPIRY + 1).seconds(),
         ),
+        finders_fee_basis_points: Some(0),
     };
 
     // Reject if not called by the media owner
@@ -202,6 +207,7 @@ fn try_set_ask() {
         expires: Timestamp::from_seconds(
             mock_env().block.time.plus_seconds(MIN_EXPIRY + 1).seconds(),
         ),
+        finders_fee_basis_points: Some(0),
     };
     let err = execute(
         deps.as_mut(),

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -36,7 +36,7 @@ fn ask_indexed_map() {
         reserve_for: None,
         expires: Timestamp::from_seconds(0),
         is_active: true,
-        finders_fee_basis_points: Some(0),
+        finders_fee_bps: Some(0),
     };
     let key = ask_key(collection.clone(), TOKEN_ID);
     let res = asks().save(deps.as_mut().storage, key.clone(), &ask);
@@ -51,7 +51,7 @@ fn ask_indexed_map() {
         reserve_for: None,
         expires: Timestamp::from_seconds(0),
         is_active: true,
-        finders_fee_basis_points: Some(0),
+        finders_fee_bps: Some(0),
     };
     let key2 = ask_key(collection.clone(), TOKEN_ID + 1);
     let res = asks().save(deps.as_mut().storage, key2, &ask2);

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -108,7 +108,7 @@ fn bid_indexed_map() {
 fn setup_contract(deps: DepsMut) {
     let msg = InstantiateMsg {
         operators: vec!["operator".to_string()],
-        trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
+        trading_fee_bps: TRADING_FEE_BASIS_POINTS,
         ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         ask_filled_hook: None,
@@ -124,7 +124,7 @@ fn proper_initialization() {
 
     let msg = InstantiateMsg {
         operators: vec!["operator".to_string()],
-        trading_fee_basis_points: TRADING_FEE_BASIS_POINTS,
+        trading_fee_bps: TRADING_FEE_BASIS_POINTS,
         ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         ask_filled_hook: None,

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -20,6 +20,7 @@ const TOKEN_ID: u32 = 123;
 const TRADING_FEE_BASIS_POINTS: u64 = 200; // 2%
 const MIN_EXPIRY: u64 = 24 * 60 * 60; // 24 hours (in seconds)
 const MAX_EXPIRY: u64 = 180 * 24 * 60 * 60; // 6 months (in seconds)
+const MAX_FINDERS_FEE_BPS: u64 = 1000; // 10%
 
 #[test]
 fn ask_indexed_map() {
@@ -112,6 +113,7 @@ fn setup_contract(deps: DepsMut) {
         ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         ask_filled_hook: None,
+        max_finders_fee_bps: MAX_FINDERS_FEE_BPS,
     };
     let info = mock_info(CREATOR, &[]);
     let res = instantiate(deps, mock_env(), info, msg).unwrap();
@@ -128,6 +130,7 @@ fn proper_initialization() {
         ask_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         bid_expiry: ExpiryRange::new(MIN_EXPIRY, MAX_EXPIRY),
         ask_filled_hook: None,
+        max_finders_fee_bps: MAX_FINDERS_FEE_BPS,
     };
     let info = mock_info("creator", &coins(1000, NATIVE_DENOM));
 

--- a/types/contracts/marketplace/execute_msg.d.ts
+++ b/types/contracts/marketplace/execute_msg.d.ts
@@ -4,6 +4,7 @@ export type ExecuteMsg = ({
 set_ask: {
 collection: string
 expires: Timestamp
+finders_fee_basis_points?: (number | null)
 funds_recipient?: (string | null)
 price: Coin
 reserve_for?: (string | null)
@@ -34,6 +35,7 @@ token_id: number
 set_bid: {
 collection: string
 expires: Timestamp
+finder?: (string | null)
 token_id: number
 [k: string]: unknown
 }
@@ -47,6 +49,7 @@ token_id: number
 accept_bid: {
 bidder: string
 collection: string
+finder?: (string | null)
 token_id: number
 [k: string]: unknown
 }
@@ -60,6 +63,7 @@ expires: Timestamp
 accept_collection_bid: {
 bidder: string
 collection: string
+finder?: (string | null)
 token_id: number
 [k: string]: unknown
 }

--- a/types/contracts/marketplace/instantiate_msg.d.ts
+++ b/types/contracts/marketplace/instantiate_msg.d.ts
@@ -11,12 +11,16 @@ ask_filled_hook?: (string | null)
  */
 bid_expiry: ExpiryRange
 /**
+ * Max basis points for the finders fee
+ */
+max_finders_fee_bps: number
+/**
  * Operators are entites that are responsible for maintaining the active state of Asks. They listen to NFT transfer events, and update the active state of Asks.
  */
 operators: string[]
 /**
  * Fair Burn fee for winning bids 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250
  */
-trading_fee_basis_points: number
+trading_fee_bps: number
 [k: string]: unknown
 }

--- a/types/contracts/marketplace/params_response.d.ts
+++ b/types/contracts/marketplace/params_response.d.ts
@@ -21,12 +21,16 @@ ask_expiry: ExpiryRange
  */
 bid_expiry: ExpiryRange
 /**
+ * Max value for the finders fee
+ */
+max_finders_fee_bps: Decimal
+/**
  * Operators are entites that are responsible for maintaining the active state of Asks They listen to NFT transfer events, and update the active state of Asks
  */
 operators: Addr[]
 /**
  * Fair Burn fee for winning bids 0.25% = 25, 0.5% = 50, 1% = 100, 2.5% = 250
  */
-trading_fee_basis_points: Decimal
+trading_fee_bps: Decimal
 [k: string]: unknown
 }

--- a/types/contracts/marketplace/shared-types.d.ts
+++ b/types/contracts/marketplace/shared-types.d.ts
@@ -58,6 +58,7 @@ export interface Ask {
     [k: string]: unknown;
     collection: Addr;
     expires: Timestamp;
+    finders_fee_bps?: (number | null);
     funds_recipient?: (Addr | null);
     is_active: boolean;
     price: Uint128;

--- a/types/contracts/marketplace/sudo_msg.d.ts
+++ b/types/contracts/marketplace/sudo_msg.d.ts
@@ -4,8 +4,9 @@ export type SudoMsg = ({
 update_params: {
 ask_expiry?: (ExpiryRange | null)
 bid_expiry?: (ExpiryRange | null)
+max_finders_fee_bps?: (number | null)
 operators?: (string[] | null)
-trading_fee_basis_points?: (number | null)
+trading_fee_bps?: (number | null)
 [k: string]: unknown
 }
 } | {


### PR DESCRIPTION
Fixes #139 

This is like an affiliate fee for filling asks. The seller can set a finder's fee. When a bid is placed, a `finder` address is sent in the transaction which will receive a payout for filling the ask.