### PR TITLE
Use cw721-base approval query helper

### DIFF
--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -13,18 +13,6 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("Invalid roylties")]
-    InvalidRoyalties {},
-
-    #[error("No roylities exist for token_id")]
-    NoRoyaltiesForTokenId {},
-
-    #[error("Funds sent don't match bid amount")]
-    IncorrectBidFunds {},
-
-    #[error("InvalidExpiration")]
-    InvalidExpiration {},
-
     #[error("InvalidPrice")]
     InvalidPrice {},
 
@@ -40,14 +28,8 @@ pub enum ContractError {
     #[error("BidNotStale")]
     BidNotStale {},
 
-    #[error("Bid not found")]
-    BidNotFound {},
-
     #[error("PriceTooSmall: {0}")]
     PriceTooSmall(Uint128),
-
-    #[error("Contract needs approval")]
-    NeedsApproval {},
 
     #[error("Token reserved")]
     TokenReserved {},

--- a/types/contracts/marketplace/query_msg.d.ts
+++ b/types/contracts/marketplace/query_msg.d.ts
@@ -111,6 +111,10 @@ ask_created_hooks: {
 [k: string]: unknown
 }
 } | {
+bid_created_hooks: {
+[k: string]: unknown
+}
+} | {
 sale_hooks: {
 [k: string]: unknown
 }

--- a/types/contracts/marketplace/sudo_msg.d.ts
+++ b/types/contracts/marketplace/sudo_msg.d.ts
@@ -18,7 +18,17 @@ hook: string
 [k: string]: unknown
 }
 } | {
+add_bid_created_hook: {
+hook: string
+[k: string]: unknown
+}
+} | {
 remove_ask_created_hook: {
+hook: string
+[k: string]: unknown
+}
+} | {
+remove_bid_created_hook: {
 hook: string
 [k: string]: unknown
 }


### PR DESCRIPTION
Want to use contract helpers whenever they're available as they reduce the surface area of code (and thus bugs): https://github.com/CosmWasm/cw-nfts/blob/main/contracts/cw721-base/src/helpers.rs.