### PR TITLE
Ask CRUD hooks

### DIFF
--- a/contracts/marketplace/examples/schema.rs
+++ b/contracts/marketplace/examples/schema.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 use sg_marketplace::msg::{
-    AskCountResponse, AskCreatedHookMsg, AskOffset, AskResponse, AsksResponse, BidOffset,
-    BidResponse, BidsResponse, CollectionBidOffset, CollectionBidResponse, CollectionOffset,
+    AskCountResponse, AskHookMsg, AskOffset, AskResponse, AsksResponse, BidOffset, BidResponse,
+    BidsResponse, CollectionBidOffset, CollectionBidResponse, CollectionOffset,
     CollectionsResponse, ExecuteMsg, InstantiateMsg, ParamsResponse, QueryMsg, SaleHookMsg,
     SudoMsg,
 };
@@ -83,7 +83,7 @@ fn main() {
     );
     export_schema_with_title(&schema_for!(SaleHookMsg), &out_dir, "SaleHooksResponse");
     export_schema_with_title(
-        &schema_for!(AskCreatedHookMsg),
+        &schema_for!(AskHookMsg),
         &out_dir,
         "AskCreatedHooksResponse",
     );

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -319,12 +319,14 @@ pub fn execute_update_ask_is_active(
     ask.is_active = is_active;
     asks().save(deps.storage, ask_key(collection.clone(), token_id), &ask)?;
 
+    let hook = prepare_ask_hook(deps.as_ref(), &ask, HookAction::Update)?;
+
     let event = Event::new("update-ask-state")
         .add_attribute("collection", collection.to_string())
         .add_attribute("token_id", token_id.to_string())
         .add_attribute("is_active", is_active.to_string());
 
-    Ok(Response::new().add_event(event))
+    Ok(Response::new().add_event(event).add_submessages(hook))
 }
 
 /// Updates the ask price on a particular NFT
@@ -343,12 +345,14 @@ pub fn execute_update_ask_price(
     ask.price = price.amount;
     asks().save(deps.storage, ask_key(collection.clone(), token_id), &ask)?;
 
+    let hook = prepare_ask_hook(deps.as_ref(), &ask, HookAction::Update)?;
+
     let event = Event::new("update-ask")
         .add_attribute("collection", collection.to_string())
         .add_attribute("token_id", token_id.to_string())
         .add_attribute("price", price.to_string());
 
-    Ok(Response::new().add_event(event))
+    Ok(Response::new().add_event(event).add_submessages(hook))
 }
 
 /// Places a bid on a listed or unlisted NFT. The bid is escrowed in the contract.

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -422,7 +422,15 @@ pub enum SaleExecuteMsg {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
-pub struct AskCreatedHookMsg {
+pub enum HookAction {
+    Create,
+    Update,
+    Delete,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct AskHookMsg {
     pub collection: String,
     pub token_id: u32,
     pub seller: String,
@@ -430,7 +438,7 @@ pub struct AskCreatedHookMsg {
     pub price: Coin,
 }
 
-impl AskCreatedHookMsg {
+impl AskHookMsg {
     pub fn new(
         collection: String,
         token_id: u32,
@@ -438,7 +446,7 @@ impl AskCreatedHookMsg {
         funds_recipient: String,
         price: Coin,
     ) -> Self {
-        AskCreatedHookMsg {
+        AskHookMsg {
             collection,
             token_id,
             seller,
@@ -448,14 +456,22 @@ impl AskCreatedHookMsg {
     }
 
     /// serializes the message
-    pub fn into_binary(self) -> StdResult<Binary> {
-        let msg = AskCreatedExecuteMsg::AskCreatedHook(self);
+    pub fn into_binary(self, action: HookAction) -> StdResult<Binary> {
+        let msg = match action {
+            HookAction::Create => AskHookExecuteMsg::AskCreatedHook(self),
+            HookAction::Update => AskHookExecuteMsg::AskUpdatedHook(self),
+            HookAction::Delete => AskHookExecuteMsg::AskDeletedHook(self),
+        };
         to_binary(&msg)
     }
 
     /// creates a cosmos_msg sending this struct to the named contract
-    pub fn into_cosmos_msg<T: Into<String>>(self, contract_addr: T) -> StdResult<CosmosMsg> {
-        let msg = self.into_binary()?;
+    pub fn into_cosmos_msg<T: Into<String>>(
+        self,
+        contract_addr: T,
+        action: HookAction,
+    ) -> StdResult<CosmosMsg> {
+        let msg = self.into_binary(action)?;
         let execute = WasmMsg::Execute {
             contract_addr: contract_addr.into(),
             msg,
@@ -468,8 +484,10 @@ impl AskCreatedHookMsg {
 // This is just a helper to properly serialize the above message
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
-pub enum AskCreatedExecuteMsg {
-    AskCreatedHook(AskCreatedHookMsg),
+pub enum AskHookExecuteMsg {
+    AskCreatedHook(AskHookMsg),
+    AskUpdatedHook(AskHookMsg),
+    AskDeletedHook(AskHookMsg),
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -4,8 +4,8 @@ use crate::msg::{
     CollectionOffset, CollectionsResponse, ParamsResponse, QueryMsg,
 };
 use crate::state::{
-    ask_key, asks, bid_key, bids, collection_bid_key, collection_bids, BidKey, TokenId,
-    ASK_CREATED_HOOKS, BID_CREATED_HOOKS, SALE_HOOKS, SUDO_PARAMS,
+    ask_key, asks, bid_key, bids, collection_bid_key, collection_bids, BidKey, TokenId, ASK_HOOKS,
+    BID_CREATED_HOOKS, SALE_HOOKS, SUDO_PARAMS,
 };
 use cosmwasm_std::{entry_point, to_binary, Addr, Binary, Deps, Env, Order, StdResult};
 use cw_storage_plus::{Bound, PrefixBound};
@@ -151,7 +151,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&bidder)?,
         )?),
-        QueryMsg::AskCreatedHooks {} => to_binary(&ASK_CREATED_HOOKS.query_hooks(deps)?),
+        QueryMsg::AskCreatedHooks {} => to_binary(&ASK_HOOKS.query_hooks(deps)?),
         QueryMsg::BidCreatedHooks {} => to_binary(&BID_CREATED_HOOKS.query_hooks(deps)?),
         QueryMsg::SaleHooks {} => to_binary(&SALE_HOOKS.query_hooks(deps)?),
         QueryMsg::Params {} => to_binary(&query_params(deps)?),

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -32,7 +32,7 @@ pub struct SudoParams {
 
 pub const SUDO_PARAMS: Item<SudoParams> = Item::new("sudo-params");
 
-pub const ASK_CREATED_HOOKS: Hooks = Hooks::new("ask-created-hooks");
+pub const ASK_HOOKS: Hooks = Hooks::new("ask-hooks");
 pub const BID_CREATED_HOOKS: Hooks = Hooks::new("bid-created-hooks");
 pub const SALE_HOOKS: Hooks = Hooks::new("sale-hooks");
 

--- a/contracts/marketplace/src/sudo.rs
+++ b/contracts/marketplace/src/sudo.rs
@@ -1,7 +1,7 @@
 use crate::error::ContractError;
 use crate::helpers::{map_validate, ExpiryRange};
 use crate::msg::SudoMsg;
-use crate::state::{ASK_CREATED_HOOKS, BID_CREATED_HOOKS, SALE_HOOKS, SUDO_PARAMS};
+use crate::state::{ASK_HOOKS, BID_CREATED_HOOKS, SALE_HOOKS, SUDO_PARAMS};
 use cosmwasm_std::{entry_point, Addr, Decimal, DepsMut, Env, Uint128};
 use cw_utils::Duration;
 use sg_std::Response;
@@ -124,7 +124,7 @@ pub fn sudo_add_sale_hook(deps: DepsMut, hook: Addr) -> Result<Response, Contrac
 }
 
 pub fn sudo_add_ask_hook(deps: DepsMut, _env: Env, hook: Addr) -> Result<Response, ContractError> {
-    ASK_CREATED_HOOKS.add_hook(deps.storage, hook.clone())?;
+    ASK_HOOKS.add_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
         .add_attribute("action", "add_ask_created_hook")
@@ -151,7 +151,7 @@ pub fn sudo_remove_sale_hook(deps: DepsMut, hook: Addr) -> Result<Response, Cont
 }
 
 pub fn sudo_remove_ask_hook(deps: DepsMut, hook: Addr) -> Result<Response, ContractError> {
-    ASK_CREATED_HOOKS.remove_hook(deps.storage, hook.clone())?;
+    ASK_HOOKS.remove_hook(deps.storage, hook.clone())?;
 
     let res = Response::new()
         .add_attribute("action", "remove_ask_created_hook")


### PR DESCRIPTION
Partially fixes #169.

Instead of adding a lot of boilerplate for create, update, and delete hooks, this creates an enum for them and re-uses one message with all the `Ask` properties.

So now clients of the hook can listen to any or all of `create`, `update`, or `delete` actions for an Ask.

