### PR TITLE
Some more refactorings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "sg-marketplace"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sg-marketplace"
-version = "0.14.3"
+version = "0.14.4"
 authors = [
   "Shane Vitarana <s@noreply.publicawesome.com>",
   "Jake Hartnell <jake@publicawesome.com>",

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -368,7 +368,7 @@ pub fn execute_set_bid(
         res = res.add_message(refund_bidder)
     }
 
-    let save_bid = |store| -> StdResult<Option<Bid>> {
+    let save_bid = |store| -> StdResult<_> {
         let bid = Bid::new(
             collection.clone(),
             token_id,

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -258,10 +258,7 @@ pub fn query_asks_sorted_by_price(
     let limit = limit.unwrap_or(DEFAULT_QUERY_LIMIT).min(MAX_QUERY_LIMIT) as usize;
 
     let start = start_after.map(|offset| {
-        Bound::exclusive((
-            offset.price.u128(),
-            ask_key(collection.clone(), offset.token_id),
-        ))
+        Bound::exclusive((offset.price.u128(), ask_key(&collection, offset.token_id)))
     });
 
     let mut asks = asks()
@@ -291,10 +288,7 @@ pub fn reverse_query_asks_sorted_by_price(
     let limit = limit.unwrap_or(DEFAULT_QUERY_LIMIT).min(MAX_QUERY_LIMIT) as usize;
 
     let end = start_before.map(|offset| {
-        Bound::exclusive((
-            offset.price.u128(),
-            ask_key(collection.clone(), offset.token_id),
-        ))
+        Bound::exclusive((offset.price.u128(), ask_key(&collection, offset.token_id)))
     });
 
     let mut asks = asks()
@@ -336,7 +330,7 @@ pub fn query_asks_by_seller(
 
     let start = if let Some(start) = start_after {
         let collection = deps.api.addr_validate(&start.collection)?;
-        Some(Bound::exclusive(ask_key(collection, start.token_id)))
+        Some(Bound::exclusive(ask_key(&collection, start.token_id)))
     } else {
         None
     };
@@ -359,7 +353,7 @@ pub fn query_asks_by_seller(
 }
 
 pub fn query_ask(deps: Deps, collection: Addr, token_id: TokenId) -> StdResult<AskResponse> {
-    let ask = asks().may_load(deps.storage, ask_key(collection, token_id))?;
+    let ask = asks().may_load(deps.storage, ask_key(&collection, token_id))?;
 
     Ok(AskResponse { ask })
 }
@@ -386,9 +380,9 @@ pub fn query_bids_by_bidder(
     let start = if let Some(start) = start_after {
         let collection = deps.api.addr_validate(&start.collection)?;
         Some(Bound::exclusive(bid_key(
-            collection,
+            &collection,
             start.token_id,
-            bidder.clone(),
+            &bidder,
         )))
     } else {
         None
@@ -439,7 +433,7 @@ pub fn query_bids_sorted_by_price(
     let start: Option<Bound<(u128, BidKey)>> = start_after.map(|offset| {
         Bound::exclusive((
             offset.price.u128(),
-            bid_key(collection.clone(), offset.token_id, offset.bidder),
+            bid_key(&collection, offset.token_id, &offset.bidder),
         ))
     });
 
@@ -466,7 +460,7 @@ pub fn reverse_query_bids_sorted_by_price(
     let end: Option<Bound<(u128, BidKey)>> = start_before.map(|offset| {
         Bound::exclusive((
             offset.price.u128(),
-            bid_key(collection.clone(), offset.token_id, offset.bidder),
+            bid_key(&collection, offset.token_id, &offset.bidder),
         ))
     });
 
@@ -497,7 +491,7 @@ pub fn query_bids_by_bidder_sorted_by_expiry(
             match bid.bid {
                 Some(bid) => Some(Bound::exclusive((
                     bid.expires_at.seconds(),
-                    bid_key(collection, offset.token_id, bidder.clone()),
+                    bid_key(&collection, offset.token_id, &bidder),
                 ))),
                 None => None,
             }
@@ -522,7 +516,7 @@ pub fn query_collection_bid(
     collection: Addr,
     bidder: Addr,
 ) -> StdResult<CollectionBidResponse> {
-    let bid = collection_bids().may_load(deps.storage, collection_bid_key(collection, bidder))?;
+    let bid = collection_bids().may_load(deps.storage, collection_bid_key(&collection, &bidder))?;
 
     Ok(CollectionBidResponse { bid })
 }

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -64,8 +64,8 @@ pub struct Ask {
 /// Primary key for asks: (collection, token_id)
 pub type AskKey = (Addr, TokenId);
 /// Convenience ask key constructor
-pub fn ask_key(collection: Addr, token_id: TokenId) -> AskKey {
-    (collection, token_id)
+pub fn ask_key(collection: &Addr, token_id: TokenId) -> AskKey {
+    (collection.clone(), token_id)
 }
 
 /// Defines indices for accessing Asks
@@ -129,8 +129,8 @@ impl Bid {
 /// Primary key for bids: (collection, token_id, bidder)
 pub type BidKey = (Addr, TokenId, Addr);
 /// Convenience bid key constructor
-pub fn bid_key(collection: Addr, token_id: TokenId, bidder: Addr) -> BidKey {
-    (collection, token_id, bidder)
+pub fn bid_key(collection: &Addr, token_id: TokenId, bidder: &Addr) -> BidKey {
+    (collection.clone(), token_id, bidder.clone())
 }
 
 /// Defines incides for accessing bids
@@ -192,8 +192,8 @@ pub struct CollectionBid {
 /// Primary key for bids: (collection, token_id, bidder)
 pub type CollectionBidKey = (Addr, Addr);
 /// Convenience collection bid key constructor
-pub fn collection_bid_key(collection: Addr, bidder: Addr) -> CollectionBidKey {
-    (collection, bidder)
+pub fn collection_bid_key(collection: &Addr, bidder: &Addr) -> CollectionBidKey {
+    (collection.clone(), bidder.clone())
 }
 
 /// Defines incides for accessing collection bids

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -42,7 +42,7 @@ fn ask_indexed_map() {
         is_active: true,
         finders_fee_bps: Some(0),
     };
-    let key = ask_key(collection.clone(), TOKEN_ID);
+    let key = ask_key(&collection, TOKEN_ID);
     let res = asks().save(deps.as_mut().storage, key.clone(), &ask);
     assert!(res.is_ok());
 
@@ -58,7 +58,7 @@ fn ask_indexed_map() {
         is_active: true,
         finders_fee_bps: Some(0),
     };
-    let key2 = ask_key(collection.clone(), TOKEN_ID + 1);
+    let key2 = ask_key(&collection, TOKEN_ID + 1);
     let res = asks().save(deps.as_mut().storage, key2, &ask2);
     assert!(res.is_ok());
 
@@ -88,7 +88,7 @@ fn bid_indexed_map() {
         finders_fee_bps: None,
         expires_at: Timestamp::from_seconds(0),
     };
-    let key = bid_key(collection.clone(), TOKEN_ID, bidder.clone());
+    let key = bid_key(&collection, TOKEN_ID, &bidder);
     let res = bids().save(deps.as_mut().storage, key.clone(), &bid);
     assert!(res.is_ok());
 
@@ -100,7 +100,7 @@ fn bid_indexed_map() {
         finders_fee_bps: None,
         expires_at: Timestamp::from_seconds(0),
     };
-    let key2 = bid_key(collection, TOKEN_ID + 1, bidder.clone());
+    let key2 = bid_key(&collection, TOKEN_ID + 1, &bidder);
     let res = bids().save(deps.as_mut().storage, key2, &bid2);
     assert!(res.is_ok());
 


### PR DESCRIPTION
* Replaces `match` with the `if let` syntactic sugar in some places to reduce rightward drift
* Pass references to ask and bid key constructures instead of cloning
* Use a closure to make  `set_bid()` more DRY and readable