### PR TITLE
Add `sale_type` field to `Bid`

### DIFF
--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -349,8 +349,6 @@ pub fn execute_set_bid(
     } = bid_info;
     let params = SUDO_PARAMS.load(deps.storage)?;
 
-    let sale_type = asks().load(deps.storage, ask_key(&Addr::unchecked(&collection), token_id))?.sale_type;
-
     let bid_price = must_pay(&info, NATIVE_DENOM)?;
     if bid_price < params.min_price {
         return Err(ContractError::PriceTooSmall(bid_price));
@@ -372,6 +370,7 @@ pub fn execute_set_bid(
     }
 
     let existing_ask = asks().may_load(deps.storage, ask_key.clone())?;
+    let mut sale_type: SaleType = SaleType::Auction;
 
     if let Some(ask) = existing_ask.clone() {
         if ask.is_expired(&env.block) {
@@ -385,6 +384,8 @@ pub fn execute_set_bid(
                 return Err(ContractError::TokenReserved {});
             }
         }
+
+        sale_type = ask.sale_type;
     }
 
     let save_bid = |store| -> StdResult<_> {

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -1786,6 +1786,7 @@ fn new_bid_refund() {
     };
     let bid = Bid {
         collection,
+        sale_type: SaleType::Auction,
         token_id: TOKEN_ID,
         bidder,
         price: Uint128::from(150u128),

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -113,6 +113,7 @@ pub fn asks<'a>() -> IndexedMap<'a, AskKey, Ask, AskIndicies<'a>> {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Bid {
     pub collection: Addr,
+    pub sale_type: SaleType,
     pub token_id: TokenId,
     pub bidder: Addr,
     pub price: Uint128,
@@ -123,6 +124,7 @@ pub struct Bid {
 impl Bid {
     pub fn new(
         collection: Addr,
+        sale_type: SaleType,
         token_id: TokenId,
         bidder: Addr,
         price: Uint128,
@@ -131,6 +133,7 @@ impl Bid {
     ) -> Self {
         Bid {
             collection,
+            sale_type,
             token_id,
             bidder,
             price,

--- a/contracts/marketplace/src/unit_tests.rs
+++ b/contracts/marketplace/src/unit_tests.rs
@@ -82,6 +82,7 @@ fn bid_indexed_map() {
 
     let bid = Bid {
         collection: collection.clone(),
+        sale_type: SaleType::Auction,
         token_id: TOKEN_ID,
         bidder: bidder.clone(),
         price: Uint128::from(500u128),
@@ -94,6 +95,7 @@ fn bid_indexed_map() {
 
     let bid2 = Bid {
         collection: collection.clone(),
+        sale_type: SaleType::Auction,
         token_id: TOKEN_ID + 1,
         bidder: bidder.clone(),
         price: Uint128::from(500u128),


### PR DESCRIPTION
Adds `sale_type` field to `Bid` & `BidInfo`; closes #216.

Note: starting on `src/execute.rs:372`, `sale_type` is assumed to be `SaleType::Auction` if there is no pre-existing `Ask`.
In a real-world scenario, a bid without a pre-existing ask wouldn't be possible, therefore setting `sale_type` inside of the `Some(ask) = existing_ask.clone()` block is safe.

Code in question:
```rust
let existing_ask = asks().may_load(deps.storage, ask_key.clone())?;
let mut sale_type: SaleType = SaleType::Auction;

if let Some(ask) = existing_ask.clone() {
    if ask.is_expired(&env.block) {
        return Err(ContractError::AskExpired {});
    }
    if !ask.is_active {
        return Err(ContractError::AskNotActive {});
    }
    if let Some(reserved_for) = ask.reserve_for {
        if reserved_for != bidder {
            return Err(ContractError::TokenReserved {});
        }
    }

    sale_type = ask.sale_type;
}