### PR TITLE
Fix priority of operations error in finders fee calculation

### DIFF
--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -897,7 +897,7 @@ fn payout(
     let finders_fee = match finder {
         Some(finder) => {
             let finders_fee = finders_fee_bps
-                .map(|fee| (payment * Decimal::percent(fee) / Uint128::from(100u128)).u128())
+                .map(|fee| (payment * (Decimal::percent(fee) / Uint128::from(100u128))).u128())
                 .unwrap_or(0);
             if finders_fee > 0 {
                 res.messages.push(SubMsg::new(BankMsg::Send {


### PR DESCRIPTION
Previously, the finders fee payout was calculated like this:
```
payment * Decimal(finders_fee) / 100
```


The problem with this is apparent: `5000 * 0.02 / 100 = 1`.
The payout for this is `1 STARS`, even though it should've been `100 STARS`.

To resolve this problem, we apply the principle of priority of operations. 
Parentheses supersede multiplication and division, therefore we can group `Decimal(finders_fee) / 100` together.

The payout is now calculated like this:
```
payment * ( Decimal(finders_fee) / 100 )
```

Priority of operations: https://wtmaths.com/bodmas.html
Fixes #228