### PR TITLE
update max query limit

### DIFF
--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -13,7 +13,7 @@ use cw_utils::maybe_addr;
 
 // Query limits
 const DEFAULT_QUERY_LIMIT: u32 = 10;
-const MAX_QUERY_LIMIT: u32 = 30;
+const MAX_QUERY_LIMIT: u32 = 50;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {


### PR DESCRIPTION
Current max query limit is very low for how heavily we rely on them.  Bumping to 50 but I think we could do more, querying performance only affects rpc endpoints and not block processing we are already run multiple  queries to bypass this limit which just add more network overhead.