### PR TITLE
remove fixed price no ask check

### DIFF
--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -456,12 +456,6 @@ pub fn execute_set_bid(
 
     let existing_ask = asks().may_load(deps.storage, ask_key.clone())?;
 
-    // if the bid is placed for fixed price only but there is no ask
-    // return an error
-    if sale_type == SaleType::FixedPrice && existing_ask.is_none() {
-        return Err(ContractError::AskNotFound {});
-    }
-
     if let Some(ask) = existing_ask.clone() {
         if ask.is_expired(&env.block) {
             return Err(ContractError::AskExpired {});

--- a/contracts/marketplace/src/multitest.rs
+++ b/contracts/marketplace/src/multitest.rs
@@ -3704,7 +3704,7 @@ fn try_bid_sale_type() {
 
     let bidder2 = setup_second_bidder_account(&mut router).unwrap();
 
-    // Bidder makes bid
+    // Bidder makes bid on NFT with no ask
     let set_bid_msg = ExecuteMsg::SetBid {
         sale_type: SaleType::FixedPrice,
         collection: collection.to_string(),
@@ -3720,11 +3720,7 @@ fn try_bid_sale_type() {
         &coins(100, NATIVE_DENOM),
     );
 
-    assert!(res.is_err());
-    assert_eq!(
-        res.unwrap_err().source().unwrap().to_string(),
-        ContractError::AskNotFound {}.to_string()
-    );
+    assert!(res.is_ok());
 
     // Bidder makes bid with Auction
     let set_bid_msg = ExecuteMsg::SetBid {


### PR DESCRIPTION
bidder makes bid on NFT with no ask price

seller lists fixedprice NFT like "buy it now". bidder makes bid on NFT with fixedprice, but a different amount. can still finalize sale by accepting collection bids or other single bids.

seller lists auction NFT with reserve price. bids must be equal or above reserve price.