### PR TITLE
Range offers

### DIFF
--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -68,6 +68,14 @@ pub enum ExecuteMsg {
         finder: Option<String>,
         finders_fee_bps: Option<u64>,
     },
+    /// Place multiple bids
+    SetBids {
+        collection: String,
+        token_ids: Vec<TokenId>,
+        expires: Timestamp,
+        finder: Option<String>,
+        finders_fee_bps: Option<u64>,
+    },
     BuyNow {
         collection: String,
         token_id: TokenId,

--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -241,7 +241,7 @@ impl Order for CollectionBid {
     }
 }
 
-/// Primary key for bids: (collection, token_id, bidder)
+/// Primary key for bids: (collection, bidder)
 pub type CollectionBidKey = (Addr, Addr);
 /// Convenience collection bid key constructor
 pub fn collection_bid_key(collection: &Addr, bidder: &Addr) -> CollectionBidKey {


### PR DESCRIPTION
Place multiple offers with a single message with multiple `token_id`s. Enables trait offers.
