### PR TITLE
Marketplace v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "sg-marketplace"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "base-minter",
  "cosmwasm-schema",

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sg-marketplace"
-version = "1.3.0"
+version = "1.4.0"
 authors = [
   "Shane Vitarana <s@noreply.publicawesome.com>",
   "Jake Hartnell <jake@publicawesome.com>",

--- a/contracts/marketplace/schema/sg-marketplace.json
+++ b/contracts/marketplace/schema/sg-marketplace.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "sg-marketplace",
-  "contract_version": "1.3.0",
+  "contract_version": "1.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -341,6 +341,55 @@
               "token_id"
             ],
             "properties": {
+              "collection": {
+                "type": "string"
+              },
+              "expires": {
+                "$ref": "#/definitions/Timestamp"
+              },
+              "finder": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "finders_fee_bps": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "token_id": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "buy_for"
+        ],
+        "properties": {
+          "buy_for": {
+            "type": "object",
+            "required": [
+              "asset_recipient",
+              "collection",
+              "expires",
+              "token_id"
+            ],
+            "properties": {
+              "asset_recipient": {
+                "type": "string"
+              },
               "collection": {
                 "type": "string"
               },

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -203,7 +203,7 @@ pub fn execute(
                 finder: maybe_addr(api, finder)?,
                 finders_fee_bps,
             },
-            maybe_addr(api, Some(asset_recipient))?,
+            Some(api.addr_validate(&asset_recipient)?),
             true,
         ),
         ExecuteMsg::RemoveBid {

--- a/contracts/marketplace/src/msg.rs
+++ b/contracts/marketplace/src/msg.rs
@@ -75,6 +75,14 @@ pub enum ExecuteMsg {
         finder: Option<String>,
         finders_fee_bps: Option<u64>,
     },
+    BuyFor {
+        collection: String,
+        token_id: TokenId,
+        expires: Timestamp,
+        finder: Option<String>,
+        finders_fee_bps: Option<u64>,
+        asset_recipient: String,
+    },
     /// Remove an existing bid from an ask
     RemoveBid {
         collection: String,

--- a/contracts/marketplace/src/testing/tests/fixed_price.rs
+++ b/contracts/marketplace/src/testing/tests/fixed_price.rs
@@ -6,7 +6,8 @@ use crate::testing::helpers::nft_functions::{approve, mint};
 use crate::testing::setup::setup_accounts::setup_second_bidder_account;
 use crate::testing::setup::setup_marketplace::{setup_marketplace, LISTING_FEE, MIN_EXPIRY};
 use crate::testing::setup::templates::standard_minter_template;
-use cosmwasm_std::{coin, coins, Timestamp, Uint128};
+use cosmwasm_std::{coin, coins, Addr, Timestamp, Uint128};
+use cw721::{Cw721QueryMsg, OwnerOfResponse};
 use cw_multi_test::Executor;
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
 use test_suite::common_setup::setup_accounts_and_block::setup_block_time;
@@ -256,4 +257,90 @@ fn try_buy_now() {
     // Check contract has first bid balance
     let contract_balances = router.wrap().query_all_balances(marketplace).unwrap();
     assert_eq!(contract_balances, vec![]);
+}
+
+#[test]
+fn try_buy_for() {
+    let vt = standard_minter_template(1);
+    let (mut router, creator, bidder) = (vt.router, vt.accts.creator, vt.accts.bidder);
+    let marketplace = setup_marketplace(&mut router, creator.clone()).unwrap();
+    let minter = vt.collection_response_vec[0].minter.clone().unwrap();
+    let collection = vt.collection_response_vec[0].collection.clone().unwrap();
+    let token_id = 1;
+    let start_time = Timestamp::from_nanos(GENESIS_MINT_START_TIME);
+    setup_block_time(&mut router, GENESIS_MINT_START_TIME, None);
+
+    mint(&mut router, &creator, &minter);
+    approve(&mut router, &creator, &collection, &marketplace, token_id);
+
+    // An asking price is made by the creator
+    let set_ask = ExecuteMsg::SetAsk {
+        sale_type: SaleType::FixedPrice,
+        collection: collection.to_string(),
+        token_id,
+        price: coin(150, NATIVE_DENOM),
+        funds_recipient: None,
+        reserve_for: None,
+        expires: start_time.plus_seconds(MIN_EXPIRY + 1),
+        finders_fee_bps: Some(0),
+    };
+
+    let res = router.execute_contract(
+        creator.clone(),
+        marketplace.clone(),
+        &set_ask,
+        &listing_funds(LISTING_FEE).unwrap(),
+    );
+    assert!(res.is_ok());
+
+    // bidder buys for asset_recipient address
+    let asset_recipient = Addr::unchecked("asset_recipient".to_string());
+    let buy_for_msg = ExecuteMsg::BuyFor {
+        collection: collection.to_string(),
+        token_id,
+        finders_fee_bps: None,
+        expires: router.block_info().time.plus_seconds(MIN_EXPIRY + 1),
+        finder: None,
+        asset_recipient: asset_recipient.to_string(),
+    };
+
+    let res = router.execute_contract(
+        bidder,
+        marketplace.clone(),
+        &buy_for_msg,
+        &coins(150, NATIVE_DENOM),
+    );
+    assert!(res.is_ok());
+    let ask_query = QueryMsg::Ask {
+        collection: collection.to_string(),
+        token_id,
+    };
+    // ask should have been removed
+    let res: AskResponse = router
+        .wrap()
+        .query_wasm_smart(marketplace.clone(), &ask_query)
+        .unwrap();
+    assert_eq!(res.ask, None);
+
+    // Check creator has been paid
+    let creator_native_balances = router.wrap().query_all_balances(creator.clone()).unwrap();
+    let creator_balance_after_fee = calculated_creator_balance_after_fairburn();
+    assert_eq!(
+        creator_native_balances,
+        coins(creator_balance_after_fee.u128() + 150 - 3, NATIVE_DENOM)
+    );
+
+    // Check contract has first bid balance
+    let contract_balances = router.wrap().query_all_balances(marketplace).unwrap();
+    assert_eq!(contract_balances, vec![]);
+
+    let query_owner_msg = Cw721QueryMsg::OwnerOf {
+        token_id: token_id.to_string(),
+        include_expired: None,
+    };
+    let res: OwnerOfResponse = router
+        .wrap()
+        .query_wasm_smart(collection, &query_owner_msg)
+        .unwrap();
+    assert_eq!(res.owner, asset_recipient.to_string());
 }

--- a/typescript/packages/marketplace-types/src/Marketplace.client.ts
+++ b/typescript/packages/marketplace-types/src/Marketplace.client.ts
@@ -632,6 +632,21 @@ export interface MarketplaceInterface extends MarketplaceReadOnlyInterface {
     findersFeeBps?: number;
     tokenId: number;
   }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
+  buyFor: ({
+    assetRecipient,
+    collection,
+    expires,
+    finder,
+    findersFeeBps,
+    tokenId
+  }: {
+    assetRecipient: string;
+    collection: string;
+    expires: Timestamp;
+    finder?: string;
+    findersFeeBps?: number;
+    tokenId: number;
+  }, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]) => Promise<ExecuteResult>;
   removeBid: ({
     collection,
     tokenId
@@ -730,6 +745,7 @@ export class MarketplaceClient extends MarketplaceQueryClient implements Marketp
     this.updateAskPrice = this.updateAskPrice.bind(this);
     this.setBid = this.setBid.bind(this);
     this.buyNow = this.buyNow.bind(this);
+    this.buyFor = this.buyFor.bind(this);
     this.removeBid = this.removeBid.bind(this);
     this.acceptBid = this.acceptBid.bind(this);
     this.rejectBid = this.rejectBid.bind(this);
@@ -846,6 +862,32 @@ export class MarketplaceClient extends MarketplaceQueryClient implements Marketp
   }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       buy_now: {
+        collection,
+        expires,
+        finder,
+        finders_fee_bps: findersFeeBps,
+        token_id: tokenId
+      }
+    }, fee, memo, _funds);
+  };
+  buyFor = async ({
+    assetRecipient,
+    collection,
+    expires,
+    finder,
+    findersFeeBps,
+    tokenId
+  }: {
+    assetRecipient: string;
+    collection: string;
+    expires: Timestamp;
+    finder?: string;
+    findersFeeBps?: number;
+    tokenId: number;
+  }, fee: number | StdFee | "auto" = "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+    return await this.client.execute(this.sender, this.contractAddress, {
+      buy_for: {
+        asset_recipient: assetRecipient,
         collection,
         expires,
         finder,

--- a/typescript/packages/marketplace-types/src/Marketplace.message-composer.ts
+++ b/typescript/packages/marketplace-types/src/Marketplace.message-composer.ts
@@ -74,6 +74,21 @@ export interface MarketplaceMessage {
     findersFeeBps?: number;
     tokenId: number;
   }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
+  buyFor: ({
+    assetRecipient,
+    collection,
+    expires,
+    finder,
+    findersFeeBps,
+    tokenId
+  }: {
+    assetRecipient: string;
+    collection: string;
+    expires: Timestamp;
+    finder?: string;
+    findersFeeBps?: number;
+    tokenId: number;
+  }, _funds?: Coin[]) => MsgExecuteContractEncodeObject;
   removeBid: ({
     collection,
     tokenId
@@ -169,6 +184,7 @@ export class MarketplaceMessageComposer implements MarketplaceMessage {
     this.updateAskPrice = this.updateAskPrice.bind(this);
     this.setBid = this.setBid.bind(this);
     this.buyNow = this.buyNow.bind(this);
+    this.buyFor = this.buyFor.bind(this);
     this.removeBid = this.removeBid.bind(this);
     this.acceptBid = this.acceptBid.bind(this);
     this.rejectBid = this.rejectBid.bind(this);
@@ -322,6 +338,40 @@ export class MarketplaceMessageComposer implements MarketplaceMessage {
         contract: this.contractAddress,
         msg: toUtf8(JSON.stringify({
           buy_now: {
+            collection,
+            expires,
+            finder,
+            finders_fee_bps: findersFeeBps,
+            token_id: tokenId
+          }
+        })),
+        funds: _funds
+      })
+    };
+  };
+  buyFor = ({
+    assetRecipient,
+    collection,
+    expires,
+    finder,
+    findersFeeBps,
+    tokenId
+  }: {
+    assetRecipient: string;
+    collection: string;
+    expires: Timestamp;
+    finder?: string;
+    findersFeeBps?: number;
+    tokenId: number;
+  }, _funds?: Coin[]): MsgExecuteContractEncodeObject => {
+    return {
+      typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
+      value: MsgExecuteContract.fromPartial({
+        sender: this.sender,
+        contract: this.contractAddress,
+        msg: toUtf8(JSON.stringify({
+          buy_for: {
+            asset_recipient: assetRecipient,
             collection,
             expires,
             finder,

--- a/typescript/packages/marketplace-types/src/Marketplace.types.ts
+++ b/typescript/packages/marketplace-types/src/Marketplace.types.ts
@@ -66,6 +66,15 @@ export type ExecuteMsg = {
     token_id: number;
   };
 } | {
+  buy_for: {
+    asset_recipient: string;
+    collection: string;
+    expires: Timestamp;
+    finder?: string | null;
+    finders_fee_bps?: number | null;
+    token_id: number;
+  };
+} | {
   remove_bid: {
     collection: string;
     token_id: number;


### PR DESCRIPTION
# Changes
* Add a BuyFor execute message to the sg-marketplace contract that allows clients to buy NFTs and have them sent to an `asset_recipient` address