### PR TITLE
Marketplace V2 Expiring Orders

### DIFF
--- a/contracts/stargaze-marketplace-v2/src/error.rs
+++ b/contracts/stargaze-marketplace-v2/src/error.rs
@@ -17,14 +17,14 @@ pub enum ContractError {
     #[error("{0}")]
     MarketplaceStdError(#[from] MarketplaceStdError),
 
-    #[error("No match found")]
+    #[error("NoMatchFound")]
     NoMatchFound,
 
     #[error("InvalidInput: {0}")]
     InvalidInput(String),
 
-    #[error("InsufficientFunds")]
-    InsufficientFunds,
+    #[error("InsufficientFunds: {0}")]
+    InsufficientFunds(String),
 
     #[error("InternalError: {0}")]
     InternalError(String),

--- a/contracts/stargaze-marketplace-v2/src/events.rs
+++ b/contracts/stargaze-marketplace-v2/src/events.rs
@@ -60,6 +60,23 @@ impl<'a> From<ListingFeeEvent<'a>> for Event {
     }
 }
 
+pub struct MinExpiryFeeEvent<'a> {
+    pub ty: &'a str,
+    pub denom: &'a str,
+    pub amount: &'a Option<Uint128>,
+}
+
+impl<'a> From<MinExpiryFeeEvent<'a>> for Event {
+    fn from(lfe: MinExpiryFeeEvent) -> Self {
+        let mut event = Event::new(lfe.ty.to_string());
+        event = event.add_attribute("denom", lfe.denom.to_string());
+        if let Some(amount) = lfe.amount {
+            event = event.add_attribute("fee", amount.to_string());
+        }
+        event
+    }
+}
+
 pub struct AskEvent<'a> {
     pub ty: &'a str,
     pub ask: &'a Ask,

--- a/contracts/stargaze-marketplace-v2/src/events.rs
+++ b/contracts/stargaze-marketplace-v2/src/events.rs
@@ -60,18 +60,18 @@ impl<'a> From<ListingFeeEvent<'a>> for Event {
     }
 }
 
-pub struct MinExpiryFeeEvent<'a> {
+pub struct MinExpiryRewardEvent<'a> {
     pub ty: &'a str,
     pub denom: &'a str,
     pub amount: &'a Option<Uint128>,
 }
 
-impl<'a> From<MinExpiryFeeEvent<'a>> for Event {
-    fn from(lfe: MinExpiryFeeEvent) -> Self {
-        let mut event = Event::new(lfe.ty.to_string());
-        event = event.add_attribute("denom", lfe.denom.to_string());
-        if let Some(amount) = lfe.amount {
-            event = event.add_attribute("fee", amount.to_string());
+impl<'a> From<MinExpiryRewardEvent<'a>> for Event {
+    fn from(mre: MinExpiryRewardEvent) -> Self {
+        let mut event = Event::new(mre.ty.to_string());
+        event = event.add_attribute("denom", mre.denom.to_string());
+        if let Some(amount) = mre.amount {
+            event = event.add_attribute("reward", amount.to_string());
         }
         event
     }

--- a/contracts/stargaze-marketplace-v2/src/execute.rs
+++ b/contracts/stargaze-marketplace-v2/src/execute.rs
@@ -734,14 +734,6 @@ pub fn execute_update_bid(
         funds = funds.add(reward.clone());
     }
 
-    // Remove next expiry reward from message funds
-    let expiry_reward = validate_expiry(deps.storage, details.expiry.as_ref())?;
-    if let Some(reward) = &expiry_reward {
-        funds = funds
-            .sub(reward.clone())
-            .map_err(|_| ContractError::InsufficientFunds("expiry reward".to_string()))?;
-    }
-
     bid.details = details;
 
     let mut response = Response::new();
@@ -773,10 +765,22 @@ pub fn execute_update_bid(
             response,
         )?;
     } else {
-        // If no match is found update the bid
+        // If no match is found:
+        // * deduct bid price from funds
+        // * deduct expiry reward from funds if any
+        // * store the bid
+        // * emit event
         funds = funds
             .sub(bid.details.price.clone())
             .map_err(|_| ContractError::InsufficientFunds("bid price".to_string()))?;
+
+        // Remove next expiry reward from message funds
+        let expiry_reward = validate_expiry(deps.storage, bid.details.expiry.as_ref())?;
+        if let Some(reward) = &expiry_reward {
+            funds = funds
+                .sub(reward.clone())
+                .map_err(|_| ContractError::InsufficientFunds("expiry reward".to_string()))?;
+        }
 
         bid.save(deps.storage)?;
 
@@ -981,7 +985,8 @@ pub fn execute_set_collection_bid(
             .sub(collection_bid.details.price.clone())
             .map_err(|_| ContractError::InsufficientFunds("collection bid price".to_string()))?;
 
-        if let Some(reward) = collection_bid.details.expiry_reward() {
+        let expiry_reward = validate_expiry(deps.storage, collection_bid.details.expiry.as_ref())?;
+        if let Some(reward) = &expiry_reward {
             funds = funds
                 .sub(reward.clone())
                 .map_err(|_| ContractError::InsufficientFunds("expiry reward".to_string()))?;
@@ -1064,14 +1069,6 @@ pub fn execute_update_collection_bid(
         funds = funds.add(reward.clone());
     }
 
-    // Remove next expiry reward from message funds
-    let expiry_reward = validate_expiry(deps.storage, details.expiry.as_ref())?;
-    if let Some(reward) = &expiry_reward {
-        funds = funds
-            .sub(reward.clone())
-            .map_err(|_| ContractError::InsufficientFunds("expiry reward".to_string()))?;
-    }
-
     collection_bid.details = details;
 
     let mut response = Response::new();
@@ -1103,10 +1100,22 @@ pub fn execute_update_collection_bid(
             response,
         )?;
     } else {
-        // If no match is found update the bid
+        // If no match is found:
+        // * deduct collection bid price from funds
+        // * deduct expiry reward from funds if any
+        // * store the collection bid
+        // * emit event
         funds = funds
             .sub(collection_bid.details.price.clone())
             .map_err(|_| ContractError::InsufficientFunds("collection bid price".to_string()))?;
+
+        // Remove next expiry reward from message funds
+        let expiry_reward = validate_expiry(deps.storage, collection_bid.details.expiry.as_ref())?;
+        if let Some(reward) = &expiry_reward {
+            funds = funds
+                .sub(reward.clone())
+                .map_err(|_| ContractError::InsufficientFunds("expiry reward".to_string()))?;
+        }
 
         collection_bid.save(deps.storage)?;
 

--- a/contracts/stargaze-marketplace-v2/src/helpers.rs
+++ b/contracts/stargaze-marketplace-v2/src/helpers.rs
@@ -286,6 +286,9 @@ mod tests {
             maker_reward_bps: 4000,
             taker_reward_bps: 1000,
             default_denom: "ustars".to_string(),
+            max_asks_removed_per_block: 10,
+            max_bids_removed_per_block: 10,
+            max_collection_bids_removed_per_block: 10,
         };
 
         let result = divide_protocol_fees(&config, true, true).unwrap();

--- a/contracts/stargaze-marketplace-v2/src/helpers.rs
+++ b/contracts/stargaze-marketplace-v2/src/helpers.rs
@@ -1,6 +1,6 @@
 use crate::{
     orders::{Ask, Expiry, MatchingBid},
-    state::{Config, TokenId, COLLECTION_DENOMS, MIN_EXPIRY_FEES},
+    state::{Config, TokenId, COLLECTION_DENOMS, MIN_EXPIRY_REWARDS},
     ContractError,
 };
 
@@ -84,7 +84,7 @@ pub fn validate_expiry(
 
     let reward = expiry.unwrap().reward.clone();
 
-    let min_expiry_fee = MIN_EXPIRY_FEES
+    let min_expiry_reward = MIN_EXPIRY_REWARDS
         .load(storage, reward.denom.clone())
         .map_err(|_| {
             ContractError::InvalidInput(format!(
@@ -94,9 +94,9 @@ pub fn validate_expiry(
         })?;
 
     ensure!(
-        reward.amount >= min_expiry_fee,
+        reward.amount >= min_expiry_reward,
         ContractError::InvalidInput(format!(
-            "expiry reward must be greater than or equal to min expiry fee"
+            "expiry reward must be greater than or equal to min expiry reward"
         ))
     );
 

--- a/contracts/stargaze-marketplace-v2/src/lib.rs
+++ b/contracts/stargaze-marketplace-v2/src/lib.rs
@@ -11,4 +11,5 @@ pub mod helpers;
 pub mod instantiate;
 pub mod migrate;
 pub mod orders;
+pub mod sudo;
 mod tests;

--- a/contracts/stargaze-marketplace-v2/src/migrate.rs
+++ b/contracts/stargaze-marketplace-v2/src/migrate.rs
@@ -1,23 +1,66 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{DepsMut, Env, Response};
+use cosmwasm_std::{Addr, DepsMut, Env, Response};
 use cw2::set_contract_version;
+use cw_storage_plus::Item;
 
 use crate::{
     constants::{CONTRACT_NAME, CONTRACT_VERSION},
+    state::{Config, Denom, CONFIG},
     ContractError,
 };
 
 #[cw_serde]
-pub struct MigrateMsg {}
+pub struct V0_7Config {
+    /// The address of the address that will receive the protocol fees
+    pub fee_manager: Addr,
+    /// The address of the royalty registry contract
+    pub royalty_registry: Addr,
+    /// Protocol fee
+    pub protocol_fee_bps: u64,
+    /// Max value for the royalty fee
+    pub max_royalty_fee_bps: u64,
+    /// The reward paid out to the market maker. Reward is a percentage of the protocol fee
+    pub maker_reward_bps: u64,
+    /// The reward paid out to the market taker. Reward is a percentage of the protocol fee
+    pub taker_reward_bps: u64,
+    /// The default denom for all collections on the marketplace
+    pub default_denom: Denom,
+}
+
+pub const V0_7CONFIG: Item<V0_7Config> = Item::new("C");
+
+#[cw_serde]
+pub struct MigrateMsg {
+    pub max_asks_removed_per_block: u32,
+    pub max_bids_removed_per_block: u32,
+    pub max_collection_bids_removed_per_block: u32,
+}
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
     let response = Response::new();
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let v0_7config = V0_7CONFIG.load(deps.storage)?;
+
+    let v0_8config = Config {
+        fee_manager: v0_7config.fee_manager,
+        royalty_registry: v0_7config.royalty_registry,
+        protocol_fee_bps: v0_7config.protocol_fee_bps,
+        max_royalty_fee_bps: v0_7config.max_royalty_fee_bps,
+        maker_reward_bps: v0_7config.maker_reward_bps,
+        taker_reward_bps: v0_7config.taker_reward_bps,
+        default_denom: v0_7config.default_denom,
+        max_asks_removed_per_block: msg.max_asks_removed_per_block,
+        max_bids_removed_per_block: msg.max_bids_removed_per_block,
+        max_collection_bids_removed_per_block: msg.max_collection_bids_removed_per_block,
+    };
+
+    CONFIG.save(deps.storage, &v0_8config)?;
 
     Ok(response)
 }

--- a/contracts/stargaze-marketplace-v2/src/msg.rs
+++ b/contracts/stargaze-marketplace-v2/src/msg.rs
@@ -29,6 +29,12 @@ pub enum ExecuteMsg {
     RemoveListingFee {
         denom: Denom,
     },
+    SetMinExpiryFee {
+        fee: Coin,
+    },
+    RemoveMinExpiryFee {
+        denom: Denom,
+    },
     // Marketplace messages
     SetAsk {
         collection: String,

--- a/contracts/stargaze-marketplace-v2/src/msg.rs
+++ b/contracts/stargaze-marketplace-v2/src/msg.rs
@@ -123,6 +123,10 @@ pub enum QueryMsg {
         collection: String,
         query_options: Option<QueryOptions<String>>,
     },
+    #[returns(Vec<Ask>)]
+    AsksByExpiryTimestamp {
+        query_options: Option<QueryOptions<(u64, String)>>,
+    },
     #[returns(Option<Bid>)]
     Bid(String),
     #[returns(Vec<Bid>)]
@@ -140,6 +144,10 @@ pub enum QueryMsg {
         collection: String,
         query_options: Option<QueryOptions<String>>,
     },
+    #[returns(Vec<Bid>)]
+    BidsByExpiryTimestamp {
+        query_options: Option<QueryOptions<(u64, String)>>,
+    },
     #[returns(Option<CollectionBid>)]
     CollectionBid(String),
     #[returns(Vec<CollectionBid>)]
@@ -156,10 +164,22 @@ pub enum QueryMsg {
         collection: String,
         query_options: Option<QueryOptions<String>>,
     },
+    #[returns(Vec<CollectionBid>)]
+    CollectionBidsByExpiryTimestamp {
+        query_options: Option<QueryOptions<(u64, String)>>,
+    },
 }
 
 #[cw_serde]
 pub struct PriceOffset {
     pub id: OrderId,
     pub amount: u128,
+}
+
+#[cw_serde]
+pub enum SudoMsg {
+    /// BeginBlock Is called by x/cron module BeginBlocker
+    BeginBlock {},
+    /// EndBlock Is called by x/cron module EndBlocker
+    EndBlock {},
 }

--- a/contracts/stargaze-marketplace-v2/src/msg.rs
+++ b/contracts/stargaze-marketplace-v2/src/msg.rs
@@ -29,10 +29,10 @@ pub enum ExecuteMsg {
     RemoveListingFee {
         denom: Denom,
     },
-    SetMinExpiryFee {
-        fee: Coin,
+    SetMinExpiryReward {
+        min_reward: Coin,
     },
-    RemoveMinExpiryFee {
+    RemoveMinExpiryReward {
         denom: Denom,
     },
     // Marketplace messages
@@ -43,6 +43,7 @@ pub enum ExecuteMsg {
     },
     RemoveAsk {
         id: OrderId,
+        reward_recipient: Option<String>,
     },
     UpdateAsk {
         id: OrderId,
@@ -59,6 +60,7 @@ pub enum ExecuteMsg {
     },
     RemoveBid {
         id: OrderId,
+        reward_recipient: Option<String>,
     },
     UpdateBid {
         id: OrderId,
@@ -74,6 +76,7 @@ pub enum ExecuteMsg {
     },
     RemoveCollectionBid {
         id: OrderId,
+        reward_recipient: Option<String>,
     },
     UpdateCollectionBid {
         id: OrderId,

--- a/contracts/stargaze-marketplace-v2/src/orders.rs
+++ b/contracts/stargaze-marketplace-v2/src/orders.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    attr, has_coins, Addr, Api, Attribute, Coin, Deps, StdResult, Storage, Timestamp,
+    attr, has_coins, Addr, Api, Attribute, Coin, Deps, Env, StdResult, Storage, Timestamp,
 };
 use cw_address_like::AddressLike;
 use cw_utils::maybe_addr;
@@ -45,6 +45,14 @@ impl OrderDetails<String> {
 impl OrderDetails<Addr> {
     pub fn expiry_reward(&self) -> Option<&Coin> {
         self.expiry.as_ref().and_then(|e| Some(&e.reward))
+    }
+
+    pub fn is_expired(&self, env: &Env) -> bool {
+        if let Some(expiry) = &self.expiry {
+            expiry.timestamp <= env.block.time
+        } else {
+            false
+        }
     }
 }
 

--- a/contracts/stargaze-marketplace-v2/src/query.rs
+++ b/contracts/stargaze-marketplace-v2/src/query.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use cosmwasm_std::{to_json_binary, Addr, Binary, Deps, Env, StdResult};
+use cw_storage_plus::Bound;
 use sg_index_query::{QueryOptions, QueryOptionsInternal};
 
 #[cfg(not(feature = "library"))]
@@ -31,7 +32,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&collection)?,
             denom,
-            query_options.unwrap_or(QueryOptions::default()),
+            query_options.unwrap_or_default(),
         )?),
         QueryMsg::AsksByCreatorCollection {
             creator,
@@ -41,8 +42,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&creator)?,
             api.addr_validate(&collection)?,
-            query_options.unwrap_or(QueryOptions::default()),
+            query_options.unwrap_or_default(),
         )?),
+        QueryMsg::AsksByExpiryTimestamp { query_options } => to_json_binary(
+            &query_asks_by_expiry_timestamp(deps, query_options.unwrap_or_default())?,
+        ),
         QueryMsg::Bid(id) => to_json_binary(&query_bids(deps, vec![id])?.pop()),
         QueryMsg::Bids(ids) => to_json_binary(&query_bids(deps, ids)?),
         QueryMsg::BidsByTokenPrice {
@@ -55,7 +59,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             api.addr_validate(&collection)?,
             token_id,
             denom,
-            query_options.unwrap_or(QueryOptions::default()),
+            query_options.unwrap_or_default(),
         )?),
         QueryMsg::BidsByCreatorCollection {
             creator,
@@ -65,8 +69,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&creator)?,
             api.addr_validate(&collection)?,
-            query_options.unwrap_or(QueryOptions::default()),
+            query_options.unwrap_or_default(),
         )?),
+        QueryMsg::BidsByExpiryTimestamp { query_options } => to_json_binary(
+            &query_bids_by_expiry_timestamp(deps, query_options.unwrap_or_default())?,
+        ),
         QueryMsg::CollectionBid(id) => {
             to_json_binary(&query_collection_bids(deps, vec![id])?.pop())
         }
@@ -79,7 +86,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&collection)?,
             denom,
-            query_options.unwrap_or(QueryOptions::default()),
+            query_options.unwrap_or_default(),
         )?),
         QueryMsg::CollectionBidsByCreatorCollection {
             creator,
@@ -89,8 +96,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             api.addr_validate(&creator)?,
             api.addr_validate(&collection)?,
-            query_options.unwrap_or(QueryOptions::default()),
+            query_options.unwrap_or_default(),
         )?),
+        QueryMsg::CollectionBidsByExpiryTimestamp { query_options } => to_json_binary(
+            &query_collection_bids_by_expiry_timestamp(deps, query_options.unwrap_or_default())?,
+        ),
     }
 }
 
@@ -157,6 +167,30 @@ pub fn query_asks_by_creator_collection(
         .idx
         .creator_collection
         .prefix((creator, collection))
+        .range(deps.storage, min, max, order)
+        .take(limit)
+        .map(|res| res.map(|(_, ask)| ask))
+        .collect::<StdResult<Vec<_>>>()?;
+
+    Ok(results)
+}
+
+pub fn query_asks_by_expiry_timestamp(
+    deps: Deps,
+    query_options: QueryOptions<(u64, String)>,
+) -> StdResult<Vec<Ask>> {
+    let QueryOptionsInternal {
+        limit,
+        order,
+        min,
+        max,
+    } = query_options.unpack(&(|offset| (offset.0, offset.1.clone())), None, None);
+
+    let max = Some(max.unwrap_or(Bound::exclusive((u64::MAX, "".to_string()))));
+
+    let results = asks()
+        .idx
+        .expiry_timestamp
         .range(deps.storage, min, max, order)
         .take(limit)
         .map(|res| res.map(|(_, ask)| ask))
@@ -232,6 +266,30 @@ pub fn query_bids_by_creator_collection(
     Ok(results)
 }
 
+pub fn query_bids_by_expiry_timestamp(
+    deps: Deps,
+    query_options: QueryOptions<(u64, String)>,
+) -> StdResult<Vec<Bid>> {
+    let QueryOptionsInternal {
+        limit,
+        order,
+        min,
+        max,
+    } = query_options.unpack(&(|offset| (offset.0, offset.1.clone())), None, None);
+
+    let max = Some(max.unwrap_or(Bound::exclusive((u64::MAX, "".to_string()))));
+
+    let results = bids()
+        .idx
+        .expiry_timestamp
+        .range(deps.storage, min, max, order)
+        .take(limit)
+        .map(|res| res.map(|(_, bid)| bid))
+        .collect::<StdResult<Vec<_>>>()?;
+
+    Ok(results)
+}
+
 pub fn query_collection_bids(deps: Deps, ids: Vec<OrderId>) -> StdResult<Vec<CollectionBid>> {
     let mut retval = vec![];
 
@@ -287,6 +345,30 @@ pub fn query_collection_bids_by_creator_collection(
         .idx
         .creator_collection
         .prefix((creator, collection))
+        .range(deps.storage, min, max, order)
+        .take(limit)
+        .map(|res| res.map(|(_, collection_bid)| collection_bid))
+        .collect::<StdResult<Vec<_>>>()?;
+
+    Ok(results)
+}
+
+pub fn query_collection_bids_by_expiry_timestamp(
+    deps: Deps,
+    query_options: QueryOptions<(u64, String)>,
+) -> StdResult<Vec<CollectionBid>> {
+    let QueryOptionsInternal {
+        limit,
+        order,
+        min,
+        max,
+    } = query_options.unpack(&(|offset| (offset.0, offset.1.clone())), None, None);
+
+    let max = Some(max.unwrap_or(Bound::exclusive((u64::MAX, "".to_string()))));
+
+    let results = collection_bids()
+        .idx
+        .expiry_timestamp
         .range(deps.storage, min, max, order)
         .take(limit)
         .map(|res| res.map(|(_, collection_bid)| collection_bid))

--- a/contracts/stargaze-marketplace-v2/src/state.rs
+++ b/contracts/stargaze-marketplace-v2/src/state.rs
@@ -79,7 +79,7 @@ pub const COLLECTION_DENOMS: Map<Addr, Denom> = Map::new("D");
 
 pub const LISTING_FEES: Map<Denom, Uint128> = Map::new("L");
 
-pub const MIN_EXPIRY_FEES: Map<Denom, Uint128> = Map::new("E");
+pub const MIN_EXPIRY_REWARDS: Map<Denom, Uint128> = Map::new("E");
 
 pub const NONCE: Item<u64> = Item::new("N");
 
@@ -149,7 +149,11 @@ pub struct BidIndices<'a> {
 
 impl<'a> IndexList<Bid> for BidIndices<'a> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Bid>> + '_> {
-        let v: Vec<&dyn Index<Bid>> = vec![&self.token_denom_price, &self.creator_collection];
+        let v: Vec<&dyn Index<Bid>> = vec![
+            &self.token_denom_price,
+            &self.creator_collection,
+            &self.expiry_timestamp,
+        ];
         Box::new(v.into_iter())
     }
 }
@@ -199,8 +203,11 @@ pub struct CollectionBidIndices<'a> {
 
 impl<'a> IndexList<CollectionBid> for CollectionBidIndices<'a> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<CollectionBid>> + '_> {
-        let v: Vec<&dyn Index<CollectionBid>> =
-            vec![&self.collection_denom_price, &self.creator_collection];
+        let v: Vec<&dyn Index<CollectionBid>> = vec![
+            &self.collection_denom_price,
+            &self.creator_collection,
+            &self.expiry_timestamp,
+        ];
         Box::new(v.into_iter())
     }
 }

--- a/contracts/stargaze-marketplace-v2/src/sudo.rs
+++ b/contracts/stargaze-marketplace-v2/src/sudo.rs
@@ -1,0 +1,151 @@
+use cosmwasm_std::{ensure, DepsMut, Env, Response};
+use cw_utils::NativeBalance;
+use sg_index_query::{QueryBound, QueryOptions};
+use sg_marketplace_common::coin::transfer_coins;
+use std::ops::Add;
+
+use crate::{
+    events::{AskEvent, BidEvent, CollectionBidEvent},
+    msg::SudoMsg,
+    query::{
+        query_asks_by_expiry_timestamp, query_bids_by_expiry_timestamp,
+        query_collection_bids_by_expiry_timestamp,
+    },
+    state::{asks, bids, collection_bids, CONFIG},
+    ContractError,
+};
+
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractError> {
+    match msg {
+        SudoMsg::BeginBlock {} => sudo_begin_block(deps, env),
+        SudoMsg::EndBlock {} => sudo_end_block(deps, env),
+    }
+}
+
+pub fn sudo_begin_block(_deps: DepsMut, _env: Env) -> Result<Response, ContractError> {
+    Ok(Response::new())
+}
+
+pub fn sudo_end_block(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+
+    let mut accrued_fees = NativeBalance(vec![]);
+
+    let mut response = Response::new();
+
+    // Remove expired asks
+    let expired_asks = query_asks_by_expiry_timestamp(
+        deps.as_ref(),
+        QueryOptions {
+            limit: Some(config.max_asks_removed_per_block),
+            descending: Some(false),
+            min: None,
+            max: Some(QueryBound::Exclusive((
+                env.block.time.seconds() + 1,
+                "".to_string(),
+            ))),
+        },
+    )?;
+
+    for ask in expired_asks {
+        response = response.add_event(
+            AskEvent {
+                ty: "remove-ask",
+                ask: &ask,
+                attr_keys: vec!["id", "collection", "token_id"],
+            }
+            .into(),
+        );
+
+        ensure!(
+            ask.details.expiry.is_some(),
+            ContractError::InternalError("expiry not set".to_string())
+        );
+
+        let expiry = ask.details.expiry.unwrap();
+        accrued_fees = accrued_fees.add(expiry.reward.clone());
+
+        asks().remove(deps.storage, ask.id)?;
+    }
+
+    // Remove expired bids
+    let expired_bids = query_bids_by_expiry_timestamp(
+        deps.as_ref(),
+        QueryOptions {
+            limit: Some(config.max_bids_removed_per_block),
+            descending: Some(false),
+            min: None,
+            max: Some(QueryBound::Exclusive((
+                env.block.time.seconds() + 1,
+                "".to_string(),
+            ))),
+        },
+    )?;
+
+    for bid in expired_bids {
+        response = response.add_event(
+            BidEvent {
+                ty: "remove-bid",
+                bid: &bid,
+                attr_keys: vec!["id", "collection", "token_id"],
+            }
+            .into(),
+        );
+
+        ensure!(
+            bid.details.expiry.is_some(),
+            ContractError::InternalError("expiry not set".to_string())
+        );
+
+        let expiry = bid.details.expiry.unwrap();
+        accrued_fees = accrued_fees.add(expiry.reward.clone());
+
+        bids().remove(deps.storage, bid.id)?;
+    }
+
+    // Remove expired collection bids
+    let expired_collection_bids = query_collection_bids_by_expiry_timestamp(
+        deps.as_ref(),
+        QueryOptions {
+            limit: Some(config.max_collection_bids_removed_per_block),
+            descending: Some(false),
+            min: None,
+            max: Some(QueryBound::Exclusive((
+                env.block.time.seconds() + 1,
+                "".to_string(),
+            ))),
+        },
+    )?;
+
+    for collection_bid in expired_collection_bids {
+        response = response.add_event(
+            CollectionBidEvent {
+                ty: "remove-collection-bid",
+                collection_bid: &collection_bid,
+                attr_keys: vec!["id", "collection"],
+            }
+            .into(),
+        );
+
+        ensure!(
+            collection_bid.details.expiry.is_some(),
+            ContractError::InternalError("expiry not set".to_string())
+        );
+
+        let expiry = collection_bid.details.expiry.unwrap();
+        accrued_fees = accrued_fees.add(expiry.reward.clone());
+
+        collection_bids().remove(deps.storage, collection_bid.id)?;
+    }
+
+    // Transfer accrued fees to the fee manager
+    if !accrued_fees.is_empty() {
+        response = transfer_coins(accrued_fees.into_vec(), &config.fee_manager, response);
+    }
+
+    Ok(response)
+}

--- a/contracts/stargaze-marketplace-v2/src/tests/helpers/marketplace.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/helpers/marketplace.rs
@@ -45,15 +45,15 @@ pub fn mint_and_set_ask(
     let set_ask = ExecuteMsg::SetAsk {
         collection: collection.to_string(),
         token_id: token_id.to_string(),
-        details,
+        details: details.clone(),
     };
 
-    let response = app.execute_contract(
-        owner.clone(),
-        marketplace.clone(),
-        &set_ask,
-        &[coin(LISTING_FEE, NATIVE_DENOM)],
-    );
+    let mut funds = vec![coin(LISTING_FEE, NATIVE_DENOM)];
+    if let Some(expiry) = details.expiry {
+        funds.push(expiry.reward);
+    }
+
+    let response = app.execute_contract(owner.clone(), marketplace.clone(), &set_ask, &funds);
 
     assert!(response.is_ok());
 }

--- a/contracts/stargaze-marketplace-v2/src/tests/migrations/mod.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/migrations/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod v0_8_migration;

--- a/contracts/stargaze-marketplace-v2/src/tests/migrations/v0_8_migration.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/migrations/v0_8_migration.rs
@@ -1,0 +1,163 @@
+use crate::{
+    helpers::generate_id,
+    orders::Expiry,
+    state::{asks, Denom, OrderId, TokenId},
+    tests::setup::{
+        setup_accounts::TestAccounts,
+        templates::{test_context, TestContext, TestContracts},
+    },
+};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{testing::mock_dependencies, Order, StdResult, Timestamp};
+use cosmwasm_std::{Addr, Coin};
+use cw_address_like::AddressLike;
+use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
+use sg_marketplace_common::constants::NATIVE_DENOM;
+
+#[cw_serde]
+pub struct OrderDetails<T: AddressLike> {
+    pub price: Coin,
+    pub recipient: Option<T>,
+    pub finder: Option<T>,
+}
+
+#[cw_serde]
+pub struct V0_7Ask {
+    pub id: String,
+    pub creator: Addr,
+    pub collection: Addr,
+    pub token_id: TokenId,
+    pub details: OrderDetails<Addr>,
+}
+
+/// Defines indices for accessing Asks
+pub struct V0_7AskIndices<'a> {
+    // Index Asks by collection and denom price
+    pub collection_denom_price: MultiIndex<'a, (Addr, Denom, u128), V0_7Ask, OrderId>,
+    // Index Asks by creator and collection
+    pub creator_collection: MultiIndex<'a, (Addr, Addr), V0_7Ask, OrderId>,
+}
+
+impl<'a> IndexList<V0_7Ask> for V0_7AskIndices<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<V0_7Ask>> + '_> {
+        let v: Vec<&dyn Index<V0_7Ask>> =
+            vec![&self.collection_denom_price, &self.creator_collection];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn v0_7_asks<'a>() -> IndexedMap<'a, OrderId, V0_7Ask, V0_7AskIndices<'a>> {
+    let indexes: V0_7AskIndices = V0_7AskIndices {
+        collection_denom_price: MultiIndex::new(
+            |_pk: &[u8], a: &V0_7Ask| {
+                (
+                    a.collection.clone(),
+                    a.details.price.denom.clone(),
+                    a.details.price.amount.u128(),
+                )
+            },
+            "a",
+            "a_p",
+        ),
+        creator_collection: MultiIndex::new(
+            |_pk: &[u8], a: &V0_7Ask| (a.creator.clone(), a.collection.clone()),
+            "a",
+            "a_c",
+        ),
+    };
+    IndexedMap::new("a", indexes)
+}
+
+#[test]
+fn try_handle_v0_7_asks() {
+    let TestContext {
+        contracts: TestContracts { .. },
+        accounts: TestAccounts { creator, .. },
+        ..
+    } = test_context();
+
+    let collection = Addr::unchecked("collection");
+    let token_id = "1".to_string();
+
+    let v0_7_ask = V0_7Ask {
+        id: generate_id(vec![collection.as_bytes(), token_id.as_bytes()]),
+        creator,
+        collection,
+        token_id,
+        details: OrderDetails::<Addr> {
+            price: Coin::new(100, NATIVE_DENOM),
+            recipient: None,
+            finder: None,
+        },
+    };
+
+    let mut deps = mock_dependencies();
+
+    // Store legacy v0_7 ask
+    v0_7_asks()
+        .save(&mut deps.storage, v0_7_ask.id.clone(), &v0_7_ask)
+        .unwrap();
+
+    let ask = v0_7_asks()
+        .load(&deps.storage, v0_7_ask.id.clone())
+        .unwrap();
+
+    assert_eq!(ask.id, v0_7_ask.id);
+    assert_eq!(ask.creator, v0_7_ask.creator);
+    assert_eq!(ask.collection, v0_7_ask.collection);
+    assert_eq!(ask.token_id, v0_7_ask.token_id);
+    assert_eq!(ask.details.price, v0_7_ask.details.price);
+
+    // Load v0_7 ask in v0_8 format
+    let mut ask = asks().load(&deps.storage, v0_7_ask.id.clone()).unwrap();
+    assert_eq!(ask.id, v0_7_ask.id);
+    assert_eq!(ask.creator, v0_7_ask.creator);
+    assert_eq!(ask.collection, v0_7_ask.collection);
+    assert_eq!(ask.token_id, v0_7_ask.token_id);
+    assert_eq!(ask.details.price, v0_7_ask.details.price);
+    assert_eq!(ask.details.expiry, None);
+
+    // Ensure the expiry index is empty
+    let results = asks()
+        .idx
+        .expiry_timestamp
+        .range(&deps.storage, None, None, Order::Ascending)
+        .take(1)
+        .map(|res| res.map(|(_, ask)| ask))
+        .collect::<StdResult<Vec<_>>>()
+        .unwrap();
+
+    assert_eq!(results.len(), 0);
+
+    // Update v0_8 ask with expiry
+    ask.details.expiry = Some(Expiry {
+        timestamp: Timestamp::from_seconds(100),
+        reward: Coin::new(30, NATIVE_DENOM),
+    });
+    asks()
+        .save(&mut deps.storage, ask.id.clone(), &ask)
+        .unwrap();
+
+    // Load updated v0_8 ask
+    let ask = asks().load(&deps.storage, v0_7_ask.id.clone()).unwrap();
+    assert_eq!(
+        ask.details.expiry,
+        Some(Expiry {
+            timestamp: Timestamp::from_seconds(100),
+            reward: Coin::new(30, NATIVE_DENOM),
+        })
+    );
+
+    // Check the expiry index for the ask
+    let results = asks()
+        .idx
+        .expiry_timestamp
+        .range(&deps.storage, None, None, Order::Ascending)
+        .take(1)
+        .map(|res| res.map(|(_, ask)| ask))
+        .collect::<StdResult<Vec<_>>>()
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, ask.id);
+}

--- a/contracts/stargaze-marketplace-v2/src/tests/mod.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod helpers;
 #[cfg(test)]
+mod migrations;
+#[cfg(test)]
 mod setup;
 #[cfg(test)]
 mod unit_tests;

--- a/contracts/stargaze-marketplace-v2/src/tests/setup/setup_contracts.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/setup/setup_contracts.rs
@@ -98,6 +98,9 @@ pub fn setup_marketplace(
             maker_reward_bps: 4000,
             taker_reward_bps: 1000,
             default_denom: NATIVE_DENOM.to_string(),
+            max_asks_removed_per_block: 20,
+            max_bids_removed_per_block: 20,
+            max_collection_bids_removed_per_block: 20,
         },
     };
     let marketplace = app

--- a/contracts/stargaze-marketplace-v2/src/tests/setup/setup_contracts.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/setup/setup_contracts.rs
@@ -59,7 +59,8 @@ pub fn contract_marketplace() -> Box<dyn Contract<Empty>> {
         crate::instantiate::instantiate,
         crate::query::query,
     )
-    .with_migrate(crate::migrate::migrate);
+    .with_migrate(crate::migrate::migrate)
+    .with_sudo(crate::sudo::sudo);
     Box::new(contract)
 }
 
@@ -99,9 +100,9 @@ pub fn setup_marketplace(
             maker_reward_bps: 4000,
             taker_reward_bps: 1000,
             default_denom: NATIVE_DENOM.to_string(),
-            max_asks_removed_per_block: 20,
-            max_bids_removed_per_block: 20,
-            max_collection_bids_removed_per_block: 20,
+            max_asks_removed_per_block: 10,
+            max_bids_removed_per_block: 10,
+            max_collection_bids_removed_per_block: 10,
         },
     };
     let marketplace = app

--- a/contracts/stargaze-marketplace-v2/src/tests/setup/setup_contracts.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/setup/setup_contracts.rs
@@ -13,7 +13,8 @@ use stargaze_royalty_registry::state::Config as RoyaltyRegistryConfig;
 pub const NATIVE_DENOM: &str = "ustars";
 pub const ATOM_DENOM: &str = "uatom";
 pub const JUNO_DENOM: &str = "ujuno";
-pub const LISTING_FEE: u128 = 1000000u128;
+pub const LISTING_FEE: u128 = 1_000_000u128;
+pub const MIN_EXPIRY_REWARD: u128 = 100_000u128;
 
 pub fn contract_cw721() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
@@ -134,6 +135,19 @@ pub fn setup_marketplace(
             fee: Coin {
                 denom: ATOM_DENOM.to_string(),
                 amount: Uint128::from(LISTING_FEE),
+            },
+        },
+        &[],
+    )
+    .unwrap();
+
+    app.execute_contract(
+        marketplace_admin.clone(),
+        marketplace.clone(),
+        &ExecuteMsg::SetMinExpiryReward {
+            min_reward: Coin {
+                denom: NATIVE_DENOM.to_string(),
+                amount: Uint128::from(MIN_EXPIRY_REWARD),
             },
         },
         &[],

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/admin.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/admin.rs
@@ -50,6 +50,9 @@ fn try_admin_update_config() {
             maker_reward_bps,
             taker_reward_bps,
             default_denom: NATIVE_DENOM.to_string(),
+            max_asks_removed_per_block: 20,
+            max_bids_removed_per_block: 20,
+            max_collection_bids_removed_per_block: 20,
         },
     };
 
@@ -72,6 +75,9 @@ fn try_admin_update_config() {
             maker_reward_bps: 5000,
             taker_reward_bps: 6000,
             default_denom: NATIVE_DENOM.to_string(),
+            max_asks_removed_per_block: 20,
+            max_bids_removed_per_block: 20,
+            max_collection_bids_removed_per_block: 20,
         },
     };
     // config must be checked on update

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/admin.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/admin.rs
@@ -134,6 +134,7 @@ fn try_admin_update_collection_denom() {
             price: bid_price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -185,6 +186,7 @@ fn try_admin_update_collection_denom() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &accept_bid, &[]);
@@ -199,6 +201,7 @@ fn try_admin_update_collection_denom() {
             price: bid_price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response =
@@ -217,6 +220,7 @@ fn try_admin_update_collection_denom() {
             price: bid_price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/ask_queries.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/ask_queries.rs
@@ -1,11 +1,11 @@
 use crate::{
     msg::{PriceOffset, QueryMsg},
-    orders::{Ask, OrderDetails},
+    orders::{Ask, Expiry, OrderDetails},
     tests::{
         helpers::marketplace::mint_and_set_ask,
         setup::{
             setup_accounts::TestAccounts,
-            setup_contracts::NATIVE_DENOM,
+            setup_contracts::{MIN_EXPIRY_REWARD, NATIVE_DENOM},
             templates::{test_context, TestContext, TestContracts},
         },
     },
@@ -175,6 +175,76 @@ fn try_query_asks_by_creator() {
             &QueryMsg::AsksByCreatorCollection {
                 creator: owner.to_string(),
                 collection: collection.to_string(),
+                query_options: Some(QueryOptions {
+                    descending: Some(true),
+                    limit: Some(2),
+                    min: None,
+                    max: None,
+                }),
+            },
+        )
+        .unwrap();
+
+    assert_eq!(asks.len(), 2);
+}
+
+#[test]
+fn try_query_asks_by_expiration_timestamp() {
+    let TestContext {
+        mut app,
+        contracts:
+            TestContracts {
+                marketplace,
+                collection,
+                ..
+            },
+        accounts: TestAccounts { creator, owner, .. },
+    } = test_context();
+
+    let price = coin(1000000u128, NATIVE_DENOM);
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+
+    let num_nfts: u8 = 4;
+    for idx in 1..(num_nfts + 1) {
+        let token_id = idx.to_string();
+        let expiry_timestamp = app.block_info().time.plus_seconds(100 + idx as u64);
+        mint_and_set_ask(
+            &mut app,
+            &creator,
+            &owner,
+            &marketplace,
+            &collection,
+            &token_id.to_string(),
+            OrderDetails {
+                price: price.clone(),
+                recipient: None,
+                finder: None,
+                expiry: Some(Expiry {
+                    timestamp: expiry_timestamp,
+                    reward: expiry_reward.clone(),
+                }),
+            },
+        );
+    }
+
+    // Correct number of asks returned
+    let asks = app
+        .wrap()
+        .query_wasm_smart::<Vec<Ask>>(
+            &marketplace,
+            &QueryMsg::AsksByExpiryTimestamp {
+                query_options: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(asks.len(), num_nfts as usize);
+
+    // Query Options work
+    let asks = app
+        .wrap()
+        .query_wasm_smart::<Vec<Ask>>(
+            &marketplace,
+            &QueryMsg::AsksByExpiryTimestamp {
                 query_options: Some(QueryOptions {
                     descending: Some(true),
                     limit: Some(2),

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/ask_queries.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/ask_queries.rs
@@ -43,6 +43,7 @@ fn try_query_asks_by_collection() {
                 price,
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         );
     }
@@ -132,6 +133,7 @@ fn try_query_asks_by_creator() {
                 price,
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         );
     }

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/asks.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/asks.rs
@@ -1,7 +1,7 @@
 use crate::{
     helpers::generate_id,
     msg::{ExecuteMsg, QueryMsg},
-    orders::{Ask, OrderDetails},
+    orders::{Ask, Expiry, OrderDetails},
     tests::{
         helpers::{
             marketplace::{approve, mint, mint_and_set_ask},
@@ -9,7 +9,7 @@ use crate::{
         },
         setup::{
             setup_accounts::{setup_additional_account, TestAccounts},
-            setup_contracts::{JUNO_DENOM, LISTING_FEE, NATIVE_DENOM},
+            setup_contracts::{JUNO_DENOM, LISTING_FEE, MIN_EXPIRY_REWARD, NATIVE_DENOM},
             templates::{test_context, TestContext, TestContracts},
         },
     },
@@ -18,7 +18,9 @@ use crate::{
 
 use cosmwasm_std::{coin, Addr};
 use cw_multi_test::Executor;
+use cw_utils::NativeBalance;
 use sg_marketplace_common::MarketplaceStdError;
+use std::ops::{Add, Sub};
 
 #[test]
 fn try_set_ask() {
@@ -208,6 +210,94 @@ fn try_set_ask() {
     // Create duplicate ask fails
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &set_ask, &[]);
     assert_error(response, "Unauthorized: sender is not owner".to_string());
+
+    // Create expiring ask with reward below min fails
+    approve(&mut app, &owner, &collection, &marketplace, &token_ids[1]);
+    let expiry_reward = coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM);
+    let set_ask = ExecuteMsg::SetAsk {
+        collection: collection.to_string(),
+        token_id: token_ids[1].clone(),
+        details: OrderDetails {
+            price: price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        owner.clone(),
+        marketplace.clone(),
+        &set_ask,
+        &[
+            coin(LISTING_FEE, NATIVE_DENOM),
+            coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM),
+        ],
+    );
+    assert_error(
+        response,
+        ContractError::InvalidInput(
+            "expiry reward must be greater than or equal to min expiry reward".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Create expiring ask with insufficient funds fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let set_ask = ExecuteMsg::SetAsk {
+        collection: collection.to_string(),
+        token_id: token_ids[1].clone(),
+        details: OrderDetails {
+            price: price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        owner.clone(),
+        marketplace.clone(),
+        &set_ask,
+        &[
+            coin(LISTING_FEE, NATIVE_DENOM),
+            coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM),
+        ],
+    );
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("listing fee".to_string()).to_string(),
+    );
+
+    // Create expiring ask with enough funds succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let set_ask = ExecuteMsg::SetAsk {
+        collection: collection.to_string(),
+        token_id: token_ids[1].clone(),
+        details: OrderDetails {
+            price: price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        owner.clone(),
+        marketplace.clone(),
+        &set_ask,
+        &[
+            coin(LISTING_FEE, NATIVE_DENOM),
+            coin(MIN_EXPIRY_REWARD, NATIVE_DENOM),
+        ],
+    );
+    assert!(response.is_ok());
 }
 
 #[test]
@@ -296,6 +386,144 @@ pub fn try_update_ask() {
     assert_eq!(ask.details.price, new_price);
     assert_eq!(ask.details.recipient, None);
     assert_eq!(ask.details.finder, None);
+
+    // Setting expiry with reward below min fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM);
+    let ask_id = generate_id(vec![collection.as_bytes(), token_ids[0_usize].as_bytes()]);
+    let update_ask = ExecuteMsg::UpdateAsk {
+        id: ask_id.clone(),
+        details: OrderDetails {
+            price: new_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        owner.clone(),
+        marketplace.clone(),
+        &update_ask,
+        &[coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM)],
+    );
+    assert_error(
+        response,
+        ContractError::InvalidInput(
+            "expiry reward must be greater than or equal to min expiry reward".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Setting expiry with insufficient funds fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let ask_id = generate_id(vec![collection.as_bytes(), token_ids[0_usize].as_bytes()]);
+    let update_ask = ExecuteMsg::UpdateAsk {
+        id: ask_id.clone(),
+        details: OrderDetails {
+            price: new_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        owner.clone(),
+        marketplace.clone(),
+        &update_ask,
+        &[coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM)],
+    );
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("expiry reward".to_string()).to_string(),
+    );
+
+    // Setting expiry with sufficient funds succeeds
+    let owner_balances_0 = NativeBalance(app.wrap().query_all_balances(owner.clone()).unwrap());
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let ask_id = generate_id(vec![collection.as_bytes(), token_ids[0_usize].as_bytes()]);
+    let update_ask = ExecuteMsg::UpdateAsk {
+        id: ask_id.clone(),
+        details: OrderDetails {
+            price: new_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        owner.clone(),
+        marketplace.clone(),
+        &update_ask,
+        &[expiry_reward.clone()],
+    );
+    assert!(response.is_ok());
+
+    let owner_balances_1 = NativeBalance(app.wrap().query_all_balances(owner.clone()).unwrap());
+    assert_eq!(
+        owner_balances_0.sub(expiry_reward).unwrap(),
+        owner_balances_1
+    );
+
+    // Increasing expiry reward succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD + 1_000, NATIVE_DENOM);
+    let ask_id = generate_id(vec![collection.as_bytes(), token_ids[0_usize].as_bytes()]);
+    let update_ask = ExecuteMsg::UpdateAsk {
+        id: ask_id.clone(),
+        details: OrderDetails {
+            price: new_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        owner.clone(),
+        marketplace.clone(),
+        &update_ask,
+        &[coin(1_000, NATIVE_DENOM).clone()],
+    );
+    assert!(response.is_ok());
+
+    let owner_balances_2 = NativeBalance(app.wrap().query_all_balances(owner.clone()).unwrap());
+    assert_eq!(
+        owner_balances_1.sub(coin(1_000, NATIVE_DENOM)).unwrap(),
+        owner_balances_2
+    );
+
+    // Lowering expiry reward succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let ask_id = generate_id(vec![collection.as_bytes(), token_ids[0_usize].as_bytes()]);
+    let update_ask = ExecuteMsg::UpdateAsk {
+        id: ask_id.clone(),
+        details: OrderDetails {
+            price: new_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(owner.clone(), marketplace.clone(), &update_ask, &[]);
+    assert!(response.is_ok());
+
+    let owner_balances_3 = NativeBalance(app.wrap().query_all_balances(owner.clone()).unwrap());
+    assert_eq!(
+        owner_balances_2.add(coin(1_000, NATIVE_DENOM)),
+        owner_balances_3
+    );
 }
 
 #[test]
@@ -340,7 +568,10 @@ pub fn try_remove_ask() {
 
     // Removing ask as non creator fails
     let ask_id = generate_id(vec![collection.as_bytes(), token_ids[0_usize].as_bytes()]);
-    let remove_ask = ExecuteMsg::RemoveAsk { id: ask_id.clone() };
+    let remove_ask = ExecuteMsg::RemoveAsk {
+        id: ask_id.clone(),
+        reward_recipient: None,
+    };
     let response = app.execute_contract(bidder.clone(), marketplace.clone(), &remove_ask, &[]);
     assert_error(
         response,
@@ -359,4 +590,70 @@ pub fn try_remove_ask() {
         .query_wasm_smart::<Option<Ask>>(&marketplace, &QueryMsg::Ask(ask_id))
         .unwrap();
     assert!(ask.is_none());
+}
+
+#[test]
+pub fn try_remove_expired_ask() {
+    let TestContext {
+        mut app,
+        contracts:
+            TestContracts {
+                marketplace,
+                collection,
+                ..
+            },
+        accounts:
+            TestAccounts {
+                creator,
+                owner,
+                bidder,
+                ..
+            },
+    } = test_context();
+
+    let expiry_timestamp = app.block_info().time.plus_seconds(100);
+    let token_id = "1".to_string();
+    mint_and_set_ask(
+        &mut app,
+        &creator,
+        &owner,
+        &marketplace,
+        &collection,
+        &token_id,
+        OrderDetails {
+            price: coin(1000000u128, NATIVE_DENOM),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: expiry_timestamp,
+                reward: coin(MIN_EXPIRY_REWARD, NATIVE_DENOM),
+            }),
+        },
+    );
+
+    // Removing ask before expiry fails
+    let reward_recipient = Addr::unchecked("reward_recipient");
+    let ask_id = generate_id(vec![collection.as_bytes(), token_id.as_bytes()]);
+    let remove_ask = ExecuteMsg::RemoveAsk {
+        id: ask_id.clone(),
+        reward_recipient: Some(reward_recipient.to_string()),
+    };
+    let response = app.execute_contract(bidder.clone(), marketplace.clone(), &remove_ask, &[]);
+    assert_error(
+        response,
+        MarketplaceStdError::Unauthorized(
+            "only the creator of ask can perform this action".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Removing ask after expiry succeeds, and reward is sent to reward recipient
+    app.update_block(|block| {
+        block.time = expiry_timestamp.plus_seconds(100);
+    });
+    let response = app.execute_contract(bidder.clone(), marketplace.clone(), &remove_ask, &[]);
+    assert!(response.is_ok());
+
+    let reward_balance = app.wrap().query_all_balances(reward_recipient).unwrap();
+    assert_eq!(reward_balance, vec![coin(MIN_EXPIRY_REWARD, NATIVE_DENOM)]);
 }

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/asks.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/asks.rs
@@ -55,6 +55,7 @@ fn try_set_ask() {
             price: coin(1_000_000, NATIVE_DENOM),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(bidder, marketplace.clone(), &set_ask, &[]);
@@ -73,6 +74,7 @@ fn try_set_ask() {
             price: coin(1_000_000, JUNO_DENOM),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &set_ask, &[]);
@@ -90,6 +92,7 @@ fn try_set_ask() {
             price: coin(0, NATIVE_DENOM),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &set_ask, &[]);
@@ -109,10 +112,14 @@ fn try_set_ask() {
             price: price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &set_ask, &[]);
-    assert_error(response, "No funds sent".to_string());
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("listing fee".to_string()).to_string(),
+    );
 
     // Create ask with invalid listing fee denom fails
     let recipient = Addr::unchecked("recipient".to_string());
@@ -125,6 +132,7 @@ fn try_set_ask() {
             price: price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -135,7 +143,7 @@ fn try_set_ask() {
     );
     assert_error(
         response,
-        ContractError::InvalidInput("listing fee for ujuno not found".to_string()).to_string(),
+        ContractError::InsufficientFunds("listing fee".to_string()).to_string(),
     );
 
     // Create ask with invalid listing fee amount fails
@@ -149,18 +157,18 @@ fn try_set_ask() {
             price: price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(
         owner.clone(),
         marketplace.clone(),
         &set_ask,
-        &[coin(LISTING_FEE + 1u128, NATIVE_DENOM)],
+        &[coin(LISTING_FEE - 1u128, NATIVE_DENOM)],
     );
     assert_error(
         response,
-        ContractError::InvalidInput("payment amount does not match listing fee".to_string())
-            .to_string(),
+        ContractError::InsufficientFunds("listing fee".to_string()).to_string(),
     );
 
     // Create ask succeeds
@@ -174,6 +182,7 @@ fn try_set_ask() {
             price: price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -238,6 +247,7 @@ pub fn try_update_ask() {
                 price: coin(1000000 + idx as u128, NATIVE_DENOM),
                 recipient: Some(recipient.to_string()),
                 finder: Some(finder.to_string()),
+                expiry: None,
             },
         );
         token_ids.push(token_id.clone());
@@ -251,6 +261,7 @@ pub fn try_update_ask() {
             price: coin(1000000, NATIVE_DENOM).clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(bidder.clone(), marketplace.clone(), &update_ask, &[]);
@@ -271,6 +282,7 @@ pub fn try_update_ask() {
             price: new_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &update_ask, &[]);
@@ -320,6 +332,7 @@ pub fn try_remove_ask() {
                 price: coin(1000000 + idx as u128, NATIVE_DENOM),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         );
         token_ids.push(token_id.clone());

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bid_queries.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bid_queries.rs
@@ -41,6 +41,7 @@ fn try_query_bids() {
                 price: bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response =
@@ -89,6 +90,7 @@ fn try_query_bids_by_token_price() {
                 price: bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response =
@@ -224,6 +226,7 @@ fn try_query_bids_by_creator() {
                 price: bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response =

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bid_queries.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bid_queries.rs
@@ -1,11 +1,11 @@
 use crate::{
     msg::{ExecuteMsg, PriceOffset, QueryMsg},
-    orders::{Bid, OrderDetails},
+    orders::{Bid, Expiry, OrderDetails},
     tests::{
         helpers::utils::find_attrs,
         setup::{
             setup_accounts::TestAccounts,
-            setup_contracts::{JUNO_DENOM, NATIVE_DENOM},
+            setup_contracts::{JUNO_DENOM, MIN_EXPIRY_REWARD, NATIVE_DENOM},
             templates::{test_context, TestContext, TestContracts},
         },
     },
@@ -295,4 +295,83 @@ fn try_query_bids_by_creator() {
             bids[bid_idx].details.price.amount.u128()
         );
     }
+}
+
+#[test]
+fn try_query_bids_by_expiration_timestamp() {
+    let TestContext {
+        mut app,
+        contracts:
+            TestContracts {
+                marketplace,
+                collection,
+                ..
+            },
+        accounts: TestAccounts { bidder, .. },
+    } = test_context();
+
+    let price = coin(1000000u128, NATIVE_DENOM);
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+
+    let num_bids: u8 = 4;
+    let token_id = "1".to_string();
+    let mut bid_ids: Vec<String> = vec![];
+    for idx in 1..(num_bids + 1) {
+        let expiry_timestamp = app.block_info().time.plus_seconds(100 + idx as u64);
+        let set_bid = ExecuteMsg::SetBid {
+            collection: collection.to_string(),
+            token_id: token_id.to_string(),
+            details: OrderDetails {
+                price: price.clone(),
+                recipient: None,
+                finder: None,
+                expiry: Some(Expiry {
+                    timestamp: expiry_timestamp,
+                    reward: expiry_reward.clone(),
+                }),
+            },
+        };
+        let response = app.execute_contract(
+            bidder.clone(),
+            marketplace.clone(),
+            &set_bid,
+            &[price.clone(), expiry_reward.clone()],
+        );
+        assert!(response.is_ok());
+
+        let bid_id = find_attrs(response.unwrap(), "wasm-set-bid", "id")
+            .pop()
+            .unwrap();
+        bid_ids.push(bid_id);
+    }
+
+    // Correct number of bids returned
+    let bids = app
+        .wrap()
+        .query_wasm_smart::<Vec<Bid>>(
+            &marketplace,
+            &QueryMsg::BidsByExpiryTimestamp {
+                query_options: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(bids.len(), num_bids as usize);
+
+    // Query Options work
+    let bids = app
+        .wrap()
+        .query_wasm_smart::<Vec<Bid>>(
+            &marketplace,
+            &QueryMsg::BidsByExpiryTimestamp {
+                query_options: Some(QueryOptions {
+                    descending: Some(true),
+                    limit: Some(2),
+                    min: None,
+                    max: None,
+                }),
+            },
+        )
+        .unwrap();
+
+    assert_eq!(bids.len(), 2);
 }

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bids.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bids.rs
@@ -43,6 +43,7 @@ fn try_set_bid() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -51,7 +52,10 @@ fn try_set_bid() {
         &set_bid,
         &[coin(bid_price.amount.u128() - 1u128, NATIVE_DENOM)],
     );
-    assert_error(response, ContractError::InsufficientFunds.to_string());
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("bid price".to_string()).to_string(),
+    );
 
     // Create bid with invalid denom fails
     let bid_price = coin(1_000_000, JUNO_DENOM);
@@ -62,6 +66,7 @@ fn try_set_bid() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -84,6 +89,7 @@ fn try_set_bid() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -108,6 +114,7 @@ fn try_set_bid() {
             price: bid_price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let bidder_native_balances_before =
@@ -176,6 +183,7 @@ pub fn try_update_bid() {
                 price: bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response =
@@ -195,6 +203,7 @@ pub fn try_update_bid() {
             price: coin(1000000u128, NATIVE_DENOM),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &update_bid, &[]);
@@ -214,6 +223,7 @@ pub fn try_update_bid() {
             price: new_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
 
@@ -262,6 +272,7 @@ pub fn try_remove_bid() {
                 price: price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         },
         &[price],

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bids.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bids.rs
@@ -283,7 +283,10 @@ pub fn try_remove_bid() {
         .unwrap();
 
     // Removing bid as non creator fails
-    let remove_bid = ExecuteMsg::RemoveBid { id: bid_id.clone() };
+    let remove_bid = ExecuteMsg::RemoveBid {
+        id: bid_id.clone(),
+        reward_recipient: None,
+    };
     let response = app.execute_contract(bidder2.clone(), marketplace.clone(), &remove_bid, &[]);
     assert_error(
         response,

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bids.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/bids.rs
@@ -1,11 +1,11 @@
 use crate::{
     msg::{ExecuteMsg, QueryMsg},
-    orders::{Bid, OrderDetails},
+    orders::{Bid, Expiry, OrderDetails},
     tests::{
         helpers::utils::{assert_error, find_attrs},
         setup::{
             setup_accounts::{setup_additional_account, TestAccounts},
-            setup_contracts::{JUNO_DENOM, NATIVE_DENOM},
+            setup_contracts::{JUNO_DENOM, MIN_EXPIRY_REWARD, NATIVE_DENOM},
             templates::{test_context, TestContext, TestContracts},
         },
     },
@@ -153,6 +153,90 @@ fn try_set_bid() {
     assert_eq!(bid.details.price, bid_price);
     assert_eq!(bid.details.recipient, Some(recipient));
     assert_eq!(bid.details.finder, Some(finder));
+
+    // Create expiring bid with reward below min fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM);
+    let set_bid = ExecuteMsg::SetBid {
+        collection: collection.to_string(),
+        token_id: token_id.to_string(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_bid,
+        &[
+            coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM),
+            bid_price.clone(),
+        ],
+    );
+    assert_error(
+        response,
+        ContractError::InvalidInput(
+            "expiry reward must be greater than or equal to min expiry reward".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Create expiring bid with insufficient funds fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let set_bid = ExecuteMsg::SetBid {
+        collection: collection.to_string(),
+        token_id: token_id.to_string(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_bid,
+        &[
+            coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM),
+            bid_price.clone(),
+        ],
+    );
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("expiry reward".to_string()).to_string(),
+    );
+
+    // Create expiring bid with enough funds succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let set_bid = ExecuteMsg::SetBid {
+        collection: collection.to_string(),
+        token_id: token_id.to_string(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_bid,
+        &[coin(MIN_EXPIRY_REWARD, NATIVE_DENOM), bid_price.clone()],
+    );
+    assert!(response.is_ok());
 }
 
 #[test]
@@ -233,7 +317,7 @@ pub fn try_update_bid() {
         bidder.clone(),
         marketplace.clone(),
         &update_bid,
-        &[new_price],
+        &[new_price.clone()],
     );
     assert!(response.is_ok());
     let bidder_native_balances_after =
@@ -242,6 +326,146 @@ pub fn try_update_bid() {
     assert_eq!(
         bidder_native_balances_before.add(coin(1u128, NATIVE_DENOM).clone()),
         bidder_native_balances_after
+    );
+
+    // Setting expiry with reward below min fails
+    let bid = app
+        .wrap()
+        .query_wasm_smart::<Option<Bid>>(&marketplace, &QueryMsg::Bid(bid_ids[1].clone()))
+        .unwrap()
+        .unwrap();
+    let bid_price = bid.details.price.clone();
+
+    let expiry_reward = coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM);
+    let update_bid = ExecuteMsg::UpdateBid {
+        id: bid_ids[1].clone(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_bid,
+        &[coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM)],
+    );
+    assert_error(
+        response,
+        ContractError::InvalidInput(
+            "expiry reward must be greater than or equal to min expiry reward".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Setting expiry with insufficient funds fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let update_bid = ExecuteMsg::UpdateBid {
+        id: bid_ids[1].clone(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_bid,
+        &[coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM)],
+    );
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("expiry reward".to_string()).to_string(),
+    );
+
+    // Setting expiry with sufficient funds succeeds
+    let bidder_balances_0 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let update_bid = ExecuteMsg::UpdateBid {
+        id: bid_ids[1].clone(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_bid,
+        &[expiry_reward.clone()],
+    );
+    assert!(response.is_ok());
+
+    let bidder_balances_1 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    assert_eq!(
+        bidder_balances_0.sub(expiry_reward).unwrap(),
+        bidder_balances_1
+    );
+
+    // Increasing expiry reward succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD + 1_000, NATIVE_DENOM);
+    let update_bid = ExecuteMsg::UpdateBid {
+        id: bid_ids[1].clone(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_bid,
+        &[coin(1_000, NATIVE_DENOM).clone()],
+    );
+    assert!(response.is_ok());
+
+    let bidder_balances_2 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    assert_eq!(
+        bidder_balances_1.sub(coin(1_000, NATIVE_DENOM)).unwrap(),
+        bidder_balances_2
+    );
+
+    // Lowering expiry reward succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let update_bid = ExecuteMsg::UpdateBid {
+        id: bid_ids[1].clone(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(bidder.clone(), marketplace.clone(), &update_bid, &[]);
+    assert!(response.is_ok());
+
+    let bidder_balances_3 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    assert_eq!(
+        bidder_balances_2.add(coin(1_000, NATIVE_DENOM)),
+        bidder_balances_3
     );
 }
 
@@ -305,4 +529,73 @@ pub fn try_remove_bid() {
         .query_wasm_smart::<Option<Bid>>(&marketplace, &QueryMsg::Bid(bid_id))
         .unwrap();
     assert!(bid.is_none());
+}
+
+#[test]
+pub fn try_remove_expired_bid() {
+    let TestContext {
+        mut app,
+        contracts:
+            TestContracts {
+                marketplace,
+                collection,
+                ..
+            },
+        accounts: TestAccounts { bidder, .. },
+    } = test_context();
+
+    let bidder_2 = setup_additional_account(&mut app, "bidder2").unwrap();
+
+    let expiry_timestamp = app.block_info().time.plus_seconds(100);
+    let token_id = "1".to_string();
+    let bid_price = coin(1000000u128, NATIVE_DENOM);
+    let set_bid = ExecuteMsg::SetBid {
+        collection: collection.to_string(),
+        token_id: token_id.to_string(),
+        details: OrderDetails {
+            price: bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: expiry_timestamp,
+                reward: coin(MIN_EXPIRY_REWARD, NATIVE_DENOM),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_bid,
+        &[bid_price, coin(MIN_EXPIRY_REWARD, NATIVE_DENOM)],
+    );
+    assert!(response.is_ok());
+
+    let bid_id = find_attrs(response.unwrap(), "wasm-set-bid", "id")
+        .pop()
+        .unwrap();
+
+    // Removing bid before expiry fails
+    let reward_recipient = Addr::unchecked("reward_recipient");
+    let remove_bid = ExecuteMsg::RemoveBid {
+        id: bid_id.clone(),
+        reward_recipient: Some(reward_recipient.to_string()),
+    };
+    let response = app.execute_contract(bidder_2.clone(), marketplace.clone(), &remove_bid, &[]);
+    assert_error(
+        response,
+        MarketplaceStdError::Unauthorized(
+            "only the creator of bid can perform this action".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Removing bid after expiry succeeds, and reward is sent to reward recipient
+    app.update_block(|block| {
+        block.time = expiry_timestamp.plus_seconds(100);
+    });
+    let response = app.execute_contract(bidder_2.clone(), marketplace.clone(), &remove_bid, &[]);
+    assert!(response.is_ok());
+
+    let reward_balance = app.wrap().query_all_balances(reward_recipient).unwrap();
+    assert_eq!(reward_balance, vec![coin(MIN_EXPIRY_REWARD, NATIVE_DENOM)]);
 }

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bid_queries.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bid_queries.rs
@@ -42,6 +42,7 @@ fn try_query_collection_bids_by_collection() {
                 price: collection_bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response = app.execute_contract(
@@ -95,6 +96,7 @@ fn try_query_collection_bids_by_token_price() {
                 price: collection_bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response = app.execute_contract(
@@ -207,6 +209,7 @@ fn try_query_collection_bids_by_creator() {
                 price: collection_bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response = app.execute_contract(

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bid_queries.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bid_queries.rs
@@ -291,9 +291,9 @@ fn try_query_collection_bids_by_expiration_timestamp() {
     let price = coin(1000000u128, NATIVE_DENOM);
     let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
 
-    let num_bids: u8 = 4;
+    let num_collection_bids: u8 = 4;
     let mut collection_bid_ids: Vec<String> = vec![];
-    for idx in 1..(num_bids + 1) {
+    for idx in 1..(num_collection_bids + 1) {
         let expiry_timestamp = app.block_info().time.plus_seconds(100 + idx as u64);
         let set_collection_bid = ExecuteMsg::SetCollectionBid {
             collection: collection.to_string(),
@@ -331,7 +331,7 @@ fn try_query_collection_bids_by_expiration_timestamp() {
             },
         )
         .unwrap();
-    assert_eq!(collection_bids.len(), num_bids as usize);
+    assert_eq!(collection_bids.len(), num_collection_bids as usize);
 
     // Query Options work
     let collection_bids = app

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bids.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bids.rs
@@ -290,6 +290,7 @@ pub fn try_remove_bid() {
     // Removing collection_bid as non creator fails
     let remove_collection_bid = ExecuteMsg::RemoveCollectionBid {
         id: collection_bid_id.clone(),
+        reward_recipient: None,
     };
     let response = app.execute_contract(
         owner.clone(),

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bids.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bids.rs
@@ -1,11 +1,11 @@
 use crate::{
     msg::{ExecuteMsg, QueryMsg},
-    orders::{CollectionBid, OrderDetails},
+    orders::{CollectionBid, Expiry, OrderDetails},
     tests::{
         helpers::utils::{assert_error, find_attrs},
         setup::{
             setup_accounts::{setup_additional_account, TestAccounts},
-            setup_contracts::{JUNO_DENOM, NATIVE_DENOM},
+            setup_contracts::{JUNO_DENOM, MIN_EXPIRY_REWARD, NATIVE_DENOM},
             templates::{test_context, TestContext, TestContracts},
         },
     },
@@ -155,6 +155,90 @@ fn try_set_collection_bid() {
     assert_eq!(collection_bid.details.price, collection_bid_price);
     assert_eq!(collection_bid.details.recipient, Some(recipient));
     assert_eq!(collection_bid.details.finder, Some(finder));
+
+    // Create expiring bid with reward below min fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM);
+    let set_bid = ExecuteMsg::SetCollectionBid {
+        collection: collection.to_string(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_bid,
+        &[
+            coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM),
+            collection_bid_price.clone(),
+        ],
+    );
+    assert_error(
+        response,
+        ContractError::InvalidInput(
+            "expiry reward must be greater than or equal to min expiry reward".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Create expiring bid with insufficient funds fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let set_bid = ExecuteMsg::SetCollectionBid {
+        collection: collection.to_string(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_bid,
+        &[
+            coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM),
+            collection_bid_price.clone(),
+        ],
+    );
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("expiry reward".to_string()).to_string(),
+    );
+
+    // Create expiring bid with enough funds succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let set_bid = ExecuteMsg::SetCollectionBid {
+        collection: collection.to_string(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_bid,
+        &[
+            coin(MIN_EXPIRY_REWARD, NATIVE_DENOM),
+            collection_bid_price.clone(),
+        ],
+    );
+    assert!(response.is_ok());
 }
 
 #[test]
@@ -252,6 +336,154 @@ pub fn try_update_collection_bid() {
         bidder_native_balances_before.add(coin(1u128, NATIVE_DENOM).clone()),
         bidder_native_balances_after
     );
+
+    // Setting expiry with reward below min fails
+    let collection_bid = app
+        .wrap()
+        .query_wasm_smart::<Option<CollectionBid>>(
+            &marketplace,
+            &QueryMsg::CollectionBid(collection_bid_ids[1].clone()),
+        )
+        .unwrap()
+        .unwrap();
+    let collection_bid_price = collection_bid.details.price.clone();
+
+    let expiry_reward = coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM);
+    let update_collection_bid = ExecuteMsg::UpdateCollectionBid {
+        id: collection_bid_ids[1].clone(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_collection_bid,
+        &[coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM)],
+    );
+    assert_error(
+        response,
+        ContractError::InvalidInput(
+            "expiry reward must be greater than or equal to min expiry reward".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Setting expiry with insufficient funds fails
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let update_collection_bid = ExecuteMsg::UpdateCollectionBid {
+        id: collection_bid_ids[1].clone(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_collection_bid,
+        &[coin(MIN_EXPIRY_REWARD - 1u128, NATIVE_DENOM)],
+    );
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("expiry reward".to_string()).to_string(),
+    );
+
+    // Setting expiry with sufficient funds succeeds
+    let bidder_balances_0 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let update_collection_bid = ExecuteMsg::UpdateCollectionBid {
+        id: collection_bid_ids[1].clone(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_collection_bid,
+        &[expiry_reward.clone()],
+    );
+    assert!(response.is_ok());
+
+    let bidder_balances_1 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    assert_eq!(
+        bidder_balances_0.sub(expiry_reward).unwrap(),
+        bidder_balances_1
+    );
+
+    // Increasing expiry reward succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD + 1_000, NATIVE_DENOM);
+    let update_collection_bid = ExecuteMsg::UpdateCollectionBid {
+        id: collection_bid_ids[1].clone(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_collection_bid,
+        &[coin(1_000, NATIVE_DENOM).clone()],
+    );
+    assert!(response.is_ok());
+
+    let bidder_balances_2 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    assert_eq!(
+        bidder_balances_1.sub(coin(1_000, NATIVE_DENOM)).unwrap(),
+        bidder_balances_2
+    );
+
+    // Lowering expiry reward succeeds
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+    let update_collection_bid = ExecuteMsg::UpdateCollectionBid {
+        id: collection_bid_ids[1].clone(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: expiry_reward.clone(),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &update_collection_bid,
+        &[],
+    );
+    assert!(response.is_ok());
+
+    let bidder_balances_3 = NativeBalance(app.wrap().query_all_balances(bidder.clone()).unwrap());
+    assert_eq!(
+        bidder_balances_2.add(coin(1_000, NATIVE_DENOM)),
+        bidder_balances_3
+    );
 }
 
 #[test]
@@ -323,4 +555,81 @@ pub fn try_remove_bid() {
         )
         .unwrap();
     assert!(collection_bid.is_none());
+}
+
+#[test]
+pub fn try_remove_expired_collection_bid() {
+    let TestContext {
+        mut app,
+        contracts:
+            TestContracts {
+                marketplace,
+                collection,
+                ..
+            },
+        accounts: TestAccounts { bidder, .. },
+    } = test_context();
+
+    let bidder_2 = setup_additional_account(&mut app, "bidder2").unwrap();
+
+    let expiry_timestamp = app.block_info().time.plus_seconds(100);
+    let collection_bid_price = coin(1000000u128, NATIVE_DENOM);
+    let set_collection_bid = ExecuteMsg::SetCollectionBid {
+        collection: collection.to_string(),
+        details: OrderDetails {
+            price: collection_bid_price.clone(),
+            recipient: None,
+            finder: None,
+            expiry: Some(Expiry {
+                timestamp: expiry_timestamp,
+                reward: coin(MIN_EXPIRY_REWARD, NATIVE_DENOM),
+            }),
+        },
+    };
+    let response = app.execute_contract(
+        bidder.clone(),
+        marketplace.clone(),
+        &set_collection_bid,
+        &[collection_bid_price, coin(MIN_EXPIRY_REWARD, NATIVE_DENOM)],
+    );
+    assert!(response.is_ok());
+
+    let collection_bid_id = find_attrs(response.unwrap(), "wasm-set-collection-bid", "id")
+        .pop()
+        .unwrap();
+
+    // Removing bid before expiry fails
+    let reward_recipient = Addr::unchecked("reward_recipient");
+    let remove_collection_bid = ExecuteMsg::RemoveCollectionBid {
+        id: collection_bid_id.clone(),
+        reward_recipient: Some(reward_recipient.to_string()),
+    };
+    let response = app.execute_contract(
+        bidder_2.clone(),
+        marketplace.clone(),
+        &remove_collection_bid,
+        &[],
+    );
+    assert_error(
+        response,
+        MarketplaceStdError::Unauthorized(
+            "only the creator of collection bid can perform this action".to_string(),
+        )
+        .to_string(),
+    );
+
+    // Removing bid after expiry succeeds, and reward is sent to reward recipient
+    app.update_block(|block| {
+        block.time = expiry_timestamp.plus_seconds(100);
+    });
+    let response = app.execute_contract(
+        bidder_2.clone(),
+        marketplace.clone(),
+        &remove_collection_bid,
+        &[],
+    );
+    assert!(response.is_ok());
+
+    let reward_balance = app.wrap().query_all_balances(reward_recipient).unwrap();
+    assert_eq!(reward_balance, vec![coin(MIN_EXPIRY_REWARD, NATIVE_DENOM)]);
 }

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bids.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/collection_bids.rs
@@ -40,6 +40,7 @@ fn try_set_collection_bid() {
             price: collection_bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -51,7 +52,10 @@ fn try_set_collection_bid() {
             NATIVE_DENOM,
         )],
     );
-    assert_error(response, ContractError::InsufficientFunds.to_string());
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("collection bid price".to_string()).to_string(),
+    );
 
     // Create collection_bid with invalid denom fails
     let collection_bid_price = coin(1_000_000, JUNO_DENOM);
@@ -61,6 +65,7 @@ fn try_set_collection_bid() {
             price: collection_bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -82,6 +87,7 @@ fn try_set_collection_bid() {
             price: collection_bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -105,6 +111,7 @@ fn try_set_collection_bid() {
             price: collection_bid_price.clone(),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let bidder_native_balances_before =
@@ -176,6 +183,7 @@ pub fn try_update_collection_bid() {
                 price: collection_bid_price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         };
         let response = app.execute_contract(
@@ -199,6 +207,7 @@ pub fn try_update_collection_bid() {
             price: coin(1000000u128, NATIVE_DENOM),
             recipient: Some(recipient.to_string()),
             finder: Some(finder.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -223,6 +232,7 @@ pub fn try_update_collection_bid() {
             price: new_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
 
@@ -267,6 +277,7 @@ pub fn try_remove_bid() {
                 price: price.clone(),
                 recipient: None,
                 finder: None,
+                expiry: None,
             },
         },
         &[price],

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/mod.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/mod.rs
@@ -14,3 +14,5 @@ mod collection_bid_queries;
 mod collection_bids;
 #[cfg(test)]
 mod sales;
+#[cfg(test)]
+mod sudo;

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/sales.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/sales.rs
@@ -65,6 +65,7 @@ fn try_set_ask_sale() {
             price: bid_price_1.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(bidder, marketplace.clone(), &set_bid, &[bid_price_1]);
@@ -79,6 +80,7 @@ fn try_set_ask_sale() {
             price: bid_price_2.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -99,6 +101,7 @@ fn try_set_ask_sale() {
             price: coin(5_000_000, NATIVE_DENOM),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -173,6 +176,7 @@ fn try_accept_ask_sale() {
             price: ask_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -193,6 +197,7 @@ fn try_accept_ask_sale() {
             price: ask_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -267,6 +272,7 @@ fn try_set_bid_sale() {
             price: ask_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -286,6 +292,7 @@ fn try_set_bid_sale() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response =
@@ -354,6 +361,7 @@ fn try_accept_bid_sale() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -376,6 +384,7 @@ fn try_accept_bid_sale() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(owner.clone(), marketplace.clone(), &accept_bid, &[]);
@@ -442,6 +451,7 @@ fn try_set_collection_bid_sale() {
             price: ask_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -460,6 +470,7 @@ fn try_set_collection_bid_sale() {
             price: ask_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response =
@@ -527,6 +538,7 @@ fn try_accept_collection_bid_sale() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -551,6 +563,7 @@ fn try_accept_collection_bid_sale() {
             price: coin(20_000_000, NATIVE_DENOM),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -568,6 +581,7 @@ fn try_accept_collection_bid_sale() {
             price: bid_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -643,6 +657,7 @@ fn try_sale_fee_breakdown() {
             price: ask_price.clone(),
             recipient: Some(tokens_recipient.to_string()),
             finder: Some(maker.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -665,6 +680,7 @@ fn try_sale_fee_breakdown() {
             price: ask_price.clone(),
             recipient: Some(nft_recipient.to_string()),
             finder: Some(taker.to_string()),
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -789,6 +805,7 @@ fn try_accept_ask_invalid_inputs() {
             price: ask_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(
@@ -809,6 +826,7 @@ fn try_accept_ask_invalid_inputs() {
             price: ask_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
 
@@ -821,7 +839,10 @@ fn try_accept_ask_invalid_inputs() {
     );
     assert!(response.is_err());
 
-    assert_error(response, ContractError::InsufficientFunds.to_string());
+    assert_error(
+        response,
+        ContractError::InsufficientFunds("ask price".to_string()).to_string(),
+    );
 
     let buy_price = coin(4_000_000, ATOM_DENOM);
     let accept_ask = ExecuteMsg::AcceptAsk {
@@ -830,6 +851,7 @@ fn try_accept_ask_invalid_inputs() {
             price: buy_price.clone(),
             recipient: None,
             finder: None,
+            expiry: None,
         },
     };
     let response = app.execute_contract(

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/sales.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/sales.rs
@@ -1,6 +1,6 @@
 use crate::{
     msg::{ExecuteMsg, QueryMsg},
-    orders::OrderDetails,
+    orders::{Expiry, OrderDetails},
     state::Config,
     tests::{
         helpers::{
@@ -9,7 +9,7 @@ use crate::{
         },
         setup::{
             setup_accounts::{setup_additional_account, TestAccounts},
-            setup_contracts::{ATOM_DENOM, LISTING_FEE, NATIVE_DENOM},
+            setup_contracts::{ATOM_DENOM, LISTING_FEE, MIN_EXPIRY_REWARD, NATIVE_DENOM},
             templates::{test_context, TestContext, TestContracts},
         },
     },
@@ -649,6 +649,7 @@ fn try_sale_fee_breakdown() {
     mint(&mut app, &creator, &owner, &collection, token_id);
     approve(&mut app, &owner, &collection, &marketplace, token_id);
     let ask_price = coin(5_000_000, NATIVE_DENOM);
+    let ask_expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
 
     let set_ask = ExecuteMsg::SetAsk {
         collection: collection.to_string(),
@@ -657,14 +658,17 @@ fn try_sale_fee_breakdown() {
             price: ask_price.clone(),
             recipient: Some(tokens_recipient.to_string()),
             finder: Some(maker.to_string()),
-            expiry: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: ask_expiry_reward.clone(),
+            }),
         },
     };
     let response = app.execute_contract(
         owner.clone(),
         marketplace.clone(),
         &set_ask,
-        &[coin(LISTING_FEE, NATIVE_DENOM)],
+        &[coin(LISTING_FEE, NATIVE_DENOM), ask_expiry_reward.clone()],
     );
     assert!(response.is_ok());
     let ask_id = find_attrs(response.unwrap(), "wasm-set-ask", "id")
@@ -674,20 +678,24 @@ fn try_sale_fee_breakdown() {
     // Accept ask with a taker
     let taker: Addr = Addr::unchecked("taker".to_string());
     let nft_recipient: Addr = Addr::unchecked("nft_recipient".to_string());
+    let bid_expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
     let accept_ask = ExecuteMsg::AcceptAsk {
         id: ask_id,
         details: OrderDetails {
             price: ask_price.clone(),
             recipient: Some(nft_recipient.to_string()),
             finder: Some(taker.to_string()),
-            expiry: None,
+            expiry: Some(Expiry {
+                timestamp: app.block_info().time.plus_seconds(100),
+                reward: bid_expiry_reward.clone(),
+            }),
         },
     };
     let response = app.execute_contract(
         bidder.clone(),
         marketplace.clone(),
         &accept_ask,
-        &[ask_price.clone()],
+        &[ask_price.clone(), bid_expiry_reward.clone()],
     );
     assert!(response.is_ok());
 
@@ -757,10 +765,10 @@ fn try_sale_fee_breakdown() {
 
     // Verify seller reward
     let seller_coin = coin(seller_amount.u128(), NATIVE_DENOM);
-    assert_eq!(
-        tokens_recipient_balances_after,
-        NativeBalance(vec![seller_coin.clone()])
-    );
+    let mut seller_balance = NativeBalance(vec![seller_coin.clone(), ask_expiry_reward.clone()]);
+    seller_balance.normalize();
+
+    assert_eq!(tokens_recipient_balances_after, seller_balance);
     let seller_event = find_attrs(app_response.clone(), "wasm-finalize-sale", "seller")
         .pop()
         .unwrap();

--- a/contracts/stargaze-marketplace-v2/src/tests/unit_tests/sudo.rs
+++ b/contracts/stargaze-marketplace-v2/src/tests/unit_tests/sudo.rs
@@ -1,0 +1,230 @@
+use crate::{
+    msg::{ExecuteMsg, QueryMsg, SudoMsg},
+    orders::{Ask, Bid, CollectionBid, Expiry, OrderDetails},
+    state::Config,
+    tests::{
+        helpers::marketplace::mint_and_set_ask,
+        setup::{
+            setup_accounts::{setup_additional_account, TestAccounts},
+            setup_contracts::{MIN_EXPIRY_REWARD, NATIVE_DENOM},
+            templates::{test_context, TestContext, TestContracts},
+        },
+    },
+};
+
+use cosmwasm_std::{coin, to_json_binary, Addr};
+use cw_multi_test::{Executor, SudoMsg as CwSudoMsg, WasmSudo};
+use cw_utils::NativeBalance;
+use sg_index_query::QueryOptions;
+use std::ops::{Add, Sub};
+
+#[test]
+fn try_sudo_end_block() {
+    let TestContext {
+        mut app,
+        contracts:
+            TestContracts {
+                marketplace,
+                collection,
+                ..
+            },
+        accounts:
+            TestAccounts {
+                creator,
+                owner,
+                bidder,
+                ..
+            },
+    } = test_context();
+
+    let bidder_2 = setup_additional_account(&mut app, &"bidder2").unwrap();
+
+    let price = coin(1000000u128, NATIVE_DENOM);
+    let expiry_reward = coin(MIN_EXPIRY_REWARD, NATIVE_DENOM);
+
+    let config = app
+        .wrap()
+        .query_wasm_smart::<Config<String>>(&marketplace, &QueryMsg::Config {})
+        .unwrap();
+
+    let num_orders = config.max_asks_removed_per_block + 1;
+
+    for idx in 1..(num_orders + 1) {
+        let token_id = idx.to_string();
+        let expiry_timestamp = app.block_info().time.plus_seconds(100 + idx as u64);
+        mint_and_set_ask(
+            &mut app,
+            &creator,
+            &owner,
+            &marketplace,
+            &collection,
+            &token_id.to_string(),
+            OrderDetails {
+                price: price.clone(),
+                recipient: None,
+                finder: None,
+                expiry: Some(Expiry {
+                    timestamp: expiry_timestamp,
+                    reward: expiry_reward.clone(),
+                }),
+            },
+        );
+    }
+    let asks = app
+        .wrap()
+        .query_wasm_smart::<Vec<Ask>>(
+            &marketplace,
+            &QueryMsg::AsksByExpiryTimestamp {
+                query_options: Some(QueryOptions {
+                    limit: Some(20 as u32),
+                    descending: None,
+                    min: None,
+                    max: None,
+                }),
+            },
+        )
+        .unwrap();
+    assert_eq!(asks.len() as u32, num_orders);
+
+    let token_id = 1000.to_string();
+    for idx in 1..(num_orders + 1) {
+        let expiry_timestamp = app.block_info().time.plus_seconds(100 + idx as u64);
+        let set_bid = ExecuteMsg::SetBid {
+            collection: collection.to_string(),
+            token_id: token_id.to_string(),
+            details: OrderDetails {
+                price: price.clone(),
+                recipient: None,
+                finder: None,
+                expiry: Some(Expiry {
+                    timestamp: expiry_timestamp,
+                    reward: expiry_reward.clone(),
+                }),
+            },
+        };
+        let response = app.execute_contract(
+            bidder.clone(),
+            marketplace.clone(),
+            &set_bid,
+            &[price.clone(), expiry_reward.clone()],
+        );
+        assert!(response.is_ok());
+    }
+    let bids = app
+        .wrap()
+        .query_wasm_smart::<Vec<Bid>>(
+            &marketplace,
+            &QueryMsg::BidsByExpiryTimestamp {
+                query_options: Some(QueryOptions {
+                    limit: Some(20 as u32),
+                    descending: None,
+                    min: None,
+                    max: None,
+                }),
+            },
+        )
+        .unwrap();
+    assert_eq!(bids.len() as u32, num_orders);
+
+    for idx in 1..(num_orders + 1) {
+        let collection = Addr::unchecked(format!("collection-{}", idx));
+        let expiry_timestamp = app.block_info().time.plus_seconds(100 + idx as u64);
+        let set_collection_bid = ExecuteMsg::SetCollectionBid {
+            collection: collection.to_string(),
+            details: OrderDetails {
+                price: price.clone(),
+                recipient: None,
+                finder: None,
+                expiry: Some(Expiry {
+                    timestamp: expiry_timestamp,
+                    reward: expiry_reward.clone(),
+                }),
+            },
+        };
+        let response = app.execute_contract(
+            bidder_2.clone(),
+            marketplace.clone(),
+            &set_collection_bid,
+            &[price.clone(), expiry_reward.clone()],
+        );
+        assert!(response.is_ok());
+    }
+    let collection_bids = app
+        .wrap()
+        .query_wasm_smart::<Vec<CollectionBid>>(
+            &marketplace,
+            &QueryMsg::CollectionBidsByExpiryTimestamp {
+                query_options: Some(QueryOptions {
+                    limit: Some(20 as u32),
+                    descending: None,
+                    min: None,
+                    max: None,
+                }),
+            },
+        )
+        .unwrap();
+    assert_eq!(collection_bids.len() as u32, num_orders);
+
+    app.update_block(|block| {
+        block.time = block.time.plus_seconds(110);
+    });
+
+    let fee_manager_balance_before = NativeBalance(
+        app.wrap()
+            .query_all_balances(config.fee_manager.clone())
+            .unwrap(),
+    );
+
+    let response = app.sudo(CwSudoMsg::Wasm(WasmSudo {
+        contract_addr: marketplace.clone(),
+        msg: to_json_binary(&SudoMsg::EndBlock {}).unwrap(),
+    }));
+    assert!(response.is_ok());
+
+    let fee_manager_balance_after = NativeBalance(
+        app.wrap()
+            .query_all_balances(config.fee_manager.clone())
+            .unwrap(),
+    );
+
+    let asks = app
+        .wrap()
+        .query_wasm_smart::<Vec<Ask>>(
+            &marketplace,
+            &QueryMsg::AsksByExpiryTimestamp {
+                query_options: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(asks.len(), 1);
+
+    let bids = app
+        .wrap()
+        .query_wasm_smart::<Vec<Bid>>(
+            &marketplace,
+            &QueryMsg::BidsByExpiryTimestamp {
+                query_options: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(bids.len(), 1);
+
+    let collection_bids = app
+        .wrap()
+        .query_wasm_smart::<Vec<CollectionBid>>(
+            &marketplace,
+            &QueryMsg::CollectionBidsByExpiryTimestamp {
+                query_options: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(collection_bids.len(), 1);
+
+    assert_eq!(
+        fee_manager_balance_before.add(coin(
+            MIN_EXPIRY_REWARD * 3 * (num_orders - 1) as u128,
+            NATIVE_DENOM
+        )),
+        fee_manager_balance_after
+    );
+}


### PR DESCRIPTION
# Marketplace V2 Expiring Orders

This PR implements Expiring Orders on Stargaze Marketplace V2. The implemented features are outlined below.

## Features
* Each order (Ask, Bid, Collection Bid) now has an optional `details.expiry` attribute.

```rust
pub struct OrderDetails<T: AddressLike> {
    pub price: Coin,
    pub recipient: Option<T>,
    pub finder: Option<T>,
    pub expiry: Option<Expiry>,
}

pub struct Expiry {
    pub timestamp: Timestamp,
    pub reward: Coin,
}
```

* When an Order is created or updated, the user may set a timestamp and supply funds that match the `expiry.reward`. This data signifies that whomever removes the Order after the timestamp has elapsed will be owed the expiry reward.

* There is an admin managed `MIN_EXPIRY_REWARDS` map that sets the minimum viable expiry reward for specified denoms.

* An index has been added on `expiry.timestamp` that allows traversing all Asks / Bids / Collection Bids by their expiration timestamp.

* A `Sudo::EndBlock` message has been added that traverses the Order expiration timestamps, removes some number of expired Orders, and sends the rewards to the `fee_manager` address. The number of Orders removed each block is capped at the corresponding `Config` values: `max_asks_removed_per_block`, `max_bids_removed_per_block`, `max_collection_bids_removed_per_block`.