### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Licensed Work:        Stargaze Marketplace V1
                       The Licensed Work is (c) 2021 Public Awesome
 
 Additional Use Grant: Any uses listed and defined at
-                      https://github.com/public-awesome/marketplace/README.md
+                      https://github.com/public-awesome/marketplace/blob/main/README.md
 
 Change Date:          The earlier of 2025-05-01 or a date specified by
                       Stargaze governance


### PR DESCRIPTION
The link has expired, replace it with the latest address