### PR TITLE
Fix Typos in Documentation and Comments

### DIFF
--- a/contracts/marketplace/src/state.rs
+++ b/contracts/marketplace/src/state.rs
@@ -17,7 +17,7 @@ pub struct SudoParams {
     /// Valid time range for Bids
     /// (min, max) in seconds
     pub bid_expiry: ExpiryRange,
-    /// Operators are entites that are responsible for maintaining the active state of Asks
+    /// Operators are entities that are responsible for maintaining the active state of Asks
     /// They listen to NFT transfer events, and update the active state of Asks
     pub operators: Vec<Addr>,
     /// Max value for the finders fee

--- a/contracts/marketplace/src/testing/tests/finders_fee_and_royalties.rs
+++ b/contracts/marketplace/src/testing/tests/finders_fee_and_royalties.rs
@@ -405,7 +405,7 @@ fn try_zero_royalties() {
         bidder_native_balances,
         coins(INITIAL_BALANCE - 100, NATIVE_DENOM)
     );
-    // seller should recive full amount minus fairburn (2%)
+    // seller should receive full amount minus fairburn (2%)
     let minter_balance = router.wrap().query_all_balances(minter.clone()).unwrap();
     assert_eq!(
         minter_balance,


### PR DESCRIPTION


---

**Description:**  
- Corrected a typo in the word "entities" in `state.rs` documentation.
- Fixed the spelling of "receive" in a comment in `finders_fee_and_royalties.rs`.
---